### PR TITLE
Migrate eligible classes to primary constructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ["3.10", dev]
+        # TODO: put back 3.13 when it's stable!
+        sdk: [dev]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260

--- a/lib/src/dart_clean.dart
+++ b/lib/src/dart_clean.dart
@@ -112,34 +112,21 @@ String get dartCleanOptionsUsage => _$parserForDartCleanOptions.usage;
 
 ArgParser get dartCleanOptionsParser => _$parserForDartCleanOptions;
 
-class DartCleanException implements Exception {
-  final String message;
-
-  DartCleanException(this.message);
-
+class DartCleanException(final String message) implements Exception {
   @override
   String toString() => message;
 }
 
-class _ProcessNode {
-  final int pid;
-  final String cmdline;
-  final int? parentPid;
-  final String? parentName;
-  final String? cwd;
-  final String reason;
-  final bool isDart;
+class _ProcessNode({
+  required final int pid,
+  required final String cmdline,
+  final int? parentPid,
+  final String? parentName,
+  final String? cwd,
+  required final String reason,
+  final bool isDart = true,
+}) {
   final List<_ProcessNode> children = [];
-
-  _ProcessNode({
-    required this.pid,
-    required this.cmdline,
-    this.parentPid,
-    this.parentName,
-    this.cwd,
-    required this.reason,
-    this.isDart = true,
-  });
 
   void printNode(String indent) {
     var reasonStr = reason.isNotEmpty ? ' ($reason)' : '';
@@ -158,29 +145,17 @@ class _ProcessNode {
   }
 }
 
-class DartProcess {
-  final int pid;
-  final String cmdline;
-  final int? ppid;
-  final String? parentName;
-  final String? cwd;
-  final String reason;
-  final bool isDart;
-  final List<({int pid, String command})> ancestry;
-  final int? ownerPid;
-
-  DartProcess({
-    required this.pid,
-    required this.cmdline,
-    this.ppid,
-    this.parentName,
-    this.cwd,
-    required this.reason,
-    this.isDart = true,
-    required this.ancestry,
-    this.ownerPid,
-  });
-}
+class DartProcess({
+  required final int pid,
+  required final String cmdline,
+  final int? ppid,
+  final String? parentName,
+  final String? cwd,
+  required final String reason,
+  final bool isDart = true,
+  required final List<({int pid, String command})> ancestry,
+  final int? ownerPid,
+});
 
 Future<DartProcess?> _checkProcess(int p, Set<int> protectedPids) async {
   if (protectedPids.contains(p)) {

--- a/lib/src/gerrit_view.dart
+++ b/lib/src/gerrit_view.dart
@@ -5,12 +5,8 @@ import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 
 /// Exception thrown by Gerrit View tool operations.
-class GerritViewException implements Exception {
-  final String message;
-  final int exitCode;
-
-  GerritViewException(this.message, {this.exitCode = 1});
-
+class GerritViewException(final String message, {final int exitCode = 1})
+    implements Exception {
   @override
   String toString() => message;
 }

--- a/lib/src/git_clean.dart
+++ b/lib/src/git_clean.dart
@@ -142,9 +142,7 @@ Future<void> gitClean(GitDir gitDir) async {
   }
 }
 
-class GitCleanException implements Exception {
-  final String message;
-  GitCleanException(this.message);
+class GitCleanException(final String message) implements Exception {
   @override
   String toString() => message;
 }

--- a/lib/src/git_gm.dart
+++ b/lib/src/git_gm.dart
@@ -243,12 +243,8 @@ Future<void> _runPostCommand(GitDir gitDir) async {
 /// Exception thrown by `git-gm` operations.
 ///
 /// Contains a user-friendly [message] and an suggested [exitCode].
-class GitGmException implements Exception {
-  final String message;
-  final int exitCode;
-
-  GitGmException(this.message, {this.exitCode = 1});
-
+class GitGmException(final String message, {final int exitCode = 1})
+    implements Exception {
   @override
   String toString() => message;
 }

--- a/lib/src/lint_cleanup.dart
+++ b/lib/src/lint_cleanup.dart
@@ -56,12 +56,10 @@ Future<void> lintCleanup({
   }
 }
 
-class _LintBundle {
-  _LintBundle({required this.explicit, required this.included});
-
-  final Set<String> explicit;
-  final Set<String> included;
-
+class _LintBundle({
+  required final Set<String> explicit,
+  required final Set<String> included,
+}) {
   Set<String> get allLints => explicit.union(included);
 }
 
@@ -150,9 +148,10 @@ YamlMap _openYamlMap(String path) {
 
   final analysisOptionsContent = analysisOptionsFile.readAsStringSync();
 
-  final aoYaml =
-      loadYaml(analysisOptionsContent, sourceUrl: analysisOptionsFile.uri)
-          as YamlMap;
+  final aoYaml = loadYaml(
+    analysisOptionsContent,
+    sourceUrl: analysisOptionsFile.uri,
+  ) as YamlMap;
 
   return aoYaml;
 }

--- a/lib/src/puppy.dart
+++ b/lib/src/puppy.dart
@@ -51,11 +51,7 @@ Future<void> runPuppy(RunArgs args, {String? cwd}) async {
   }
 }
 
-class PuppyException implements Exception {
-  final String message;
-
-  PuppyException(this.message);
-
+class PuppyException(final String message) implements Exception {
   @override
   String toString() => message;
 }

--- a/lib/src/tighten.dart
+++ b/lib/src/tighten.dart
@@ -253,10 +253,7 @@ Future<void> _revertConstraint(
   await file.writeAsString(editor.toString());
 }
 
-class TightenException implements Exception {
-  final String message;
-  TightenException(this.message);
-
+class TightenException(final String message) implements Exception {
   @override
   String toString() => 'TightenException: $message';
 }

--- a/lib/src/witr_types.dart
+++ b/lib/src/witr_types.dart
@@ -1,9 +1,7 @@
-class WitrData {
-  final ProcessData process;
-  final SourceData source;
-
-  WitrData({required this.process, required this.source});
-
+class WitrData({
+  required final ProcessData process,
+  required final SourceData source,
+}) {
   factory WitrData.fromJson(Map<String, dynamic> json) {
     final processJson = switch (json['Process']) {
       final Map<String, dynamic> v => v,
@@ -26,22 +24,16 @@ class WitrData {
   }
 }
 
-class SourceData {
-  final String type;
-
-  SourceData({required this.type});
-
+class SourceData({required final String type}) {
   factory SourceData.fromJson(Map<String, dynamic> json) =>
       SourceData(type: json['Type'] as String? ?? '<unknown>');
 }
 
-class ProcessData {
-  final String cmdline;
-  final List<String>? env;
-  final int? ppid;
-
-  ProcessData({required this.cmdline, this.env, this.ppid});
-
+class ProcessData({
+  required final String cmdline,
+  final List<String>? env,
+  final int? ppid,
+}) {
   factory ProcessData.fromJson(Map<String, dynamic> json) => ProcessData(
     cmdline: json['Cmdline'] as String? ?? '<unknown>',
     env: (json['Env'] as List<dynamic>? ?? []).map((e) => e as String).toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kevmoo_scripts
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.13.0-100
 
 dependencies:
   args: ^2.6.0

--- a/test/tighten_test.dart
+++ b/test/tighten_test.dart
@@ -33,11 +33,9 @@ dependencies:
 
     await tighten(cwd: d.path('simple'));
 
-    final pubspec =
-        loadYaml(
-              File(p.join(d.path('simple'), 'pubspec.yaml')).readAsStringSync(),
-            )
-            as YamlMap;
+    final pubspec = loadYaml(
+      File(p.join(d.path('simple'), 'pubspec.yaml')).readAsStringSync(),
+    ) as YamlMap;
 
     final pathConstraint = (pubspec['dependencies'] as Map)['path'] as String;
     expect(pathConstraint, isNot('any')); // Should have tightened
@@ -116,13 +114,11 @@ dependencies:
 
       await tighten(isWorkspace: true, cwd: d.path('workspace_root'));
 
-      final pkgBPubspec =
-          loadYaml(
-                File(
-                  p.join(d.path('workspace_root'), 'pkg_b', 'pubspec.yaml'),
-                ).readAsStringSync(),
-              )
-              as YamlMap;
+      final pkgBPubspec = loadYaml(
+        File(
+          p.join(d.path('workspace_root'), 'pkg_b', 'pubspec.yaml'),
+        ).readAsStringSync(),
+      ) as YamlMap;
 
       // Should still be 'any' because it was reverted
       expect((pkgBPubspec['dependencies'] as Map)['pkg_a'], 'any');
@@ -133,13 +129,11 @@ dependencies:
 
       await tighten(isWorkspace: true, cwd: d.path('workspace_root/pkg_b'));
 
-      final pkgBPubspec =
-          loadYaml(
-                File(
-                  p.join(d.path('workspace_root'), 'pkg_b', 'pubspec.yaml'),
-                ).readAsStringSync(),
-              )
-              as YamlMap;
+      final pkgBPubspec = loadYaml(
+        File(
+          p.join(d.path('workspace_root'), 'pkg_b', 'pubspec.yaml'),
+        ).readAsStringSync(),
+      ) as YamlMap;
 
       // Should still be 'any' because it was reverted
       expect((pkgBPubspec['dependencies'] as Map)['pkg_a'], 'any');


### PR DESCRIPTION
- Refactor exceptions and data classes across witr_types, git_gm, git_clean, lint_cleanup, dart_clean, puppy, tighten, and gerrit_view to use Dart 3.13 primary constructor syntax.
- Maintain named parameters in _ProcessNode for call site compatibility.
