### PR TITLE
feat: enhance git-up with closed PR branch checks and early dirty abort

### DIFF
--- a/bin/git_up.dart
+++ b/bin/git_up.dart
@@ -9,14 +9,15 @@ Future<void> main(List<String> arguments) async {
   final help = arguments.contains('--help') || arguments.contains('-h');
   if (help) {
     print('Safely switch to and update the default branch.');
-    print('Usage: git-up [--verbose | -v] [--help | -h]');
+    print('Usage: git-up [--check | -c] [--verbose | -v] [--help | -h]');
     return;
   }
 
   final verbose = arguments.contains('--verbose') || arguments.contains('-v');
+  final check = arguments.contains('--check') || arguments.contains('-c');
 
   try {
-    await gitUp();
+    await gitUp(check: check);
   } on GitUpException catch (e, stack) {
     setError(
       message: e.message,

--- a/lib/src/git_extensions.dart
+++ b/lib/src/git_extensions.dart
@@ -93,8 +93,9 @@ extension GitDirExtensions on GitDir {
 
   /// Fetches from remote, optionally pruning remote-tracking branches that no
   /// longer exist.
-  Future<void> fetch({bool prune = false}) async {
+  Future<void> fetch({bool prune = false, bool all = false}) async {
     final args = ['fetch'];
+    if (all) args.add('--all');
     if (prune) args.add('--prune');
     final result = await runCommand(args, throwOnError: false);
     if (result.exitCode != 0) {
@@ -128,28 +129,32 @@ extension GitDirExtensions on GitDir {
   /// Gets all local branches along with their upstream tracking status.
   ///
   /// Returns a map where the key is the branch name and the value is a record
-  /// containing the SHA and whether the upstream is 'gone'.
-  Future<Map<String, ({String sha, bool isUpstreamGone})>>
+  /// containing the SHA, upstream branch name (if any), and whether the
+  /// upstream is 'gone'.
+  Future<Map<String, ({String sha, String upstream, bool isUpstreamGone})>>
   getBranchesStatus() async {
-    final result = await runCommand([
-      'for-each-ref',
-      '--format=%(refname:short) %(upstream:track) %(objectname:short)',
-      'refs/heads',
-    ]);
+    const format =
+        '--format=%(refname:short)|%(upstream)|'
+        '%(upstream:track)|%(objectname:short)';
+    final result = await runCommand(['for-each-ref', format, 'refs/heads']);
 
-    final status = <String, ({String sha, bool isUpstreamGone})>{};
+    final status =
+        <String, ({String sha, String upstream, bool isUpstreamGone})>{};
     final lines = LineSplitter.split(result.stdout as String);
 
     for (final line in lines) {
-      final firstSpace = line.indexOf(' ');
-      final lastSpace = line.lastIndexOf(' ');
+      final parts = line.split('|');
+      if (parts.length == 4) {
+        final branchName = parts[0];
+        final upstream = parts[1];
+        final track = parts[2];
+        final sha = parts[3];
 
-      if (firstSpace != -1 && lastSpace > firstSpace) {
-        final branchName = line.substring(0, firstSpace);
-        final track = line.substring(firstSpace + 1, lastSpace).trim();
-        final sha = line.substring(lastSpace + 1);
-
-        status[branchName] = (sha: sha, isUpstreamGone: track == '[gone]');
+        status[branchName] = (
+          sha: sha,
+          upstream: upstream,
+          isUpstreamGone: track == '[gone]',
+        );
       }
     }
     return status;
@@ -272,21 +277,82 @@ extension GitDirExtensions on GitDir {
     return null;
   }
 
-  /// Retrieves the state of recent PRs in the repository.
+  /// Queries the GitHub API for the details of a PR by its number.
   ///
-  /// Returns a map of head branch names to their PR state.
-  Future<Map<String, String>> getRecentPrsState({int limit = 100}) async {
-    final prStates = <String, String>{};
+  /// Returns the PR details or null if not found.
+  Future<({String state, String url, int number})?> getPrInfoByNumber(
+    int prNumber,
+  ) async {
+    try {
+      final result = await Process.run('gh', [
+        'pr',
+        'view',
+        prNumber.toString(),
+        '--json',
+        'state,url,number',
+      ]);
+      if (result.exitCode == 0) {
+        final data =
+            jsonDecode(result.stdout as String) as Map<String, dynamic>;
+        return (
+          state: data['state'] as String,
+          url: data['url'] as String,
+          number: data['number'] as int,
+        );
+      }
+    } catch (_) {
+      // Ignore and return null
+    }
+    return null;
+  }
+
+  /// Queries the GitHub API for the details of a PR by branch name.
+  ///
+  /// Returns the PR details or null if not found.
+  Future<({String state, String url, int number})?> getPrInfoByBranch(
+    String branchName,
+  ) async {
+    try {
+      final result = await Process.run('gh', [
+        'pr',
+        'view',
+        branchName,
+        '--json',
+        'state,url,number',
+      ]);
+      if (result.exitCode == 0) {
+        final data =
+            jsonDecode(result.stdout as String) as Map<String, dynamic>;
+        return (
+          state: data['state'] as String,
+          url: data['url'] as String,
+          number: data['number'] as int,
+        );
+      }
+    } catch (_) {
+      // Ignore and return null
+    }
+    return null;
+  }
+
+  /// Retrieves the details of recent PRs in the repository.
+  ///
+  /// Returns a map of head branch names to their PR details.
+  Future<Map<String, ({String state, String url, int number})>>
+  getRecentPrsInfo({int limit = 100}) async {
+    final prs = <String, ({String state, String url, int number})>{};
     try {
       final result = await Process.run('gh', [
         'pr',
         'list',
         '--state',
         'all',
+        '--author',
+        '@me',
         '--limit',
         limit.toString(),
         '--json',
-        'headRefName,state',
+        'headRefName,state,url,number',
       ]);
       if (result.exitCode == 0) {
         final list = jsonDecode(result.stdout as String) as List<dynamic>;
@@ -294,8 +360,13 @@ extension GitDirExtensions on GitDir {
           if (item is Map<String, dynamic>) {
             final head = item['headRefName'] as String?;
             final state = item['state'] as String?;
-            if (head != null && state != null) {
-              prStates[head] = state;
+            final url = item['url'] as String?;
+            final number = item['number'] as int?;
+            if (head != null &&
+                state != null &&
+                url != null &&
+                number != null) {
+              prs[head] = (state: state, url: url, number: number);
             }
           }
         }
@@ -303,7 +374,16 @@ extension GitDirExtensions on GitDir {
     } catch (_) {
       // Ignore and return empty map
     }
-    return prStates;
+    return prs;
+  }
+
+  /// Checks if the working tree is dirty (has modified or staged tracked
+  /// files).
+  ///
+  /// Ignores untracked files.
+  Future<bool> isDirty() async {
+    final result = await runCommand(['status', '--porcelain', '-uno']);
+    return (result.stdout as String).trim().isNotEmpty;
   }
 
   /// Configures a standard test identity for the repository.

--- a/lib/src/git_extensions.dart
+++ b/lib/src/git_extensions.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:git/git.dart';
 
+bool mockGhUnavailableForTesting = false;
+
 /// Extensions on [GitDir] to provide high-level operations used in this
 /// package.
 ///
@@ -134,8 +136,8 @@ extension GitDirExtensions on GitDir {
   Future<Map<String, ({String sha, String upstream, bool isUpstreamGone})>>
   getBranchesStatus() async {
     const format =
-        '--format=%(refname:short)|%(upstream)|'
-        '%(upstream:track)|%(objectname:short)';
+        '--format=%(refname:short)\t%(upstream)\t'
+        '%(upstream:track)\t%(objectname:short)';
     final result = await runCommand(['for-each-ref', format, 'refs/heads']);
 
     final status =
@@ -143,7 +145,7 @@ extension GitDirExtensions on GitDir {
     final lines = LineSplitter.split(result.stdout as String);
 
     for (final line in lines) {
-      final parts = line.split('|');
+      final parts = line.split('\t');
       if (parts.length == 4) {
         final branchName = parts[0];
         final upstream = parts[1];
@@ -207,6 +209,9 @@ extension GitDirExtensions on GitDir {
 
   /// Checks if the `gh` CLI is available and authenticated.
   Future<bool> isGitHubCliAvailable() async {
+    if (mockGhUnavailableForTesting) {
+      return false;
+    }
     try {
       final result = await Process.run('gh', ['auth', 'status']);
       return result.exitCode == 0;
@@ -270,64 +275,6 @@ extension GitDirExtensions on GitDir {
         final data =
             jsonDecode(result.stdout as String) as Map<String, dynamic>;
         return data['state'] as String?;
-      }
-    } catch (_) {
-      // Ignore and return null
-    }
-    return null;
-  }
-
-  /// Queries the GitHub API for the details of a PR by its number.
-  ///
-  /// Returns the PR details or null if not found.
-  Future<({String state, String url, int number})?> getPrInfoByNumber(
-    int prNumber,
-  ) async {
-    try {
-      final result = await Process.run('gh', [
-        'pr',
-        'view',
-        prNumber.toString(),
-        '--json',
-        'state,url,number',
-      ]);
-      if (result.exitCode == 0) {
-        final data =
-            jsonDecode(result.stdout as String) as Map<String, dynamic>;
-        return (
-          state: data['state'] as String,
-          url: data['url'] as String,
-          number: data['number'] as int,
-        );
-      }
-    } catch (_) {
-      // Ignore and return null
-    }
-    return null;
-  }
-
-  /// Queries the GitHub API for the details of a PR by branch name.
-  ///
-  /// Returns the PR details or null if not found.
-  Future<({String state, String url, int number})?> getPrInfoByBranch(
-    String branchName,
-  ) async {
-    try {
-      final result = await Process.run('gh', [
-        'pr',
-        'view',
-        branchName,
-        '--json',
-        'state,url,number',
-      ]);
-      if (result.exitCode == 0) {
-        final data =
-            jsonDecode(result.stdout as String) as Map<String, dynamic>;
-        return (
-          state: data['state'] as String,
-          url: data['url'] as String,
-          number: data['number'] as int,
-        );
       }
     } catch (_) {
       // Ignore and return null

--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -254,7 +254,7 @@ Future<void> _cleanBranches(
 }) async {
   print(styleDim.wrap('Fetching and pruning...') ?? 'Fetching and pruning...');
   try {
-    await gitDir.fetch(prune: true, all: true);
+    await gitDir.fetch(prune: true);
   } catch (e) {
     printError('Warning: failed to fetch and prune: $e');
   }
@@ -384,7 +384,12 @@ Future<void> _cleanBranches(
   if (check) {
     if (activeRemoteBranches.isEmpty) {
       print('No active remote branches to check.');
-    } else if (ghAvailable && recentPrs != null) {
+    } else if (!ghAvailable) {
+      printError(
+        'Warning: GitHub CLI (gh) is not available or authenticated. '
+        'Skipping active remote branch checks.',
+      );
+    } else if (recentPrs != null) {
       var headingPrinted = false;
 
       for (final branch in activeRemoteBranches) {

--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -22,10 +22,15 @@ import 'testable_print.dart';
 ///
 /// [workingDirectory] specifies the directory to start searching for the
 /// Git root. Defaults to [Directory.current]`.path`.
-Future<void> gitUp({String? workingDirectory}) async {
+Future<void> gitUp({String? workingDirectory, bool check = false}) async {
   workingDirectory ??= Directory.current.path;
 
   final gitDir = await getGitDir(workingDirectory);
+
+  if (await gitDir.isDirty()) {
+    printError('Please commit or stash your changes and try again.');
+    throw GitUpException('Working tree is dirty.');
+  }
 
   // 1. Determine Default Branch
   final defaultBranch = await getDefaultBranch(gitDir);
@@ -60,7 +65,7 @@ Future<void> gitUp({String? workingDirectory}) async {
         'Successfully updated $defaultBranch.',
   );
 
-  await _cleanBranches(gitDir, defaultBranch);
+  await _cleanBranches(gitDir, defaultBranch, check: check);
 
   await _runPostCommand(gitDir);
 }
@@ -242,126 +247,192 @@ Future<void> _runPostCommand(GitDir gitDir) async {
   }
 }
 
-Future<void> _cleanBranches(GitDir gitDir, String defaultBranch) async {
+Future<void> _cleanBranches(
+  GitDir gitDir,
+  String defaultBranch, {
+  bool check = false,
+}) async {
   print(styleDim.wrap('Fetching and pruning...') ?? 'Fetching and pruning...');
   try {
-    await gitDir.fetch(prune: true);
+    await gitDir.fetch(prune: true, all: true);
   } catch (e) {
     printError('Warning: failed to fetch and prune: $e');
   }
 
   final branchesStatus = await gitDir.getBranchesStatus();
   final goneBranches = <String, String>{}; // name -> sha
+  final activeRemoteBranches = <String>[]; // name
 
-  for (final MapEntry(key: branchName, value: (:sha, :isUpstreamGone))
+  for (final MapEntry(
+        key: branchName,
+        value: (:sha, :upstream, :isUpstreamGone),
+      )
       in branchesStatus.entries) {
-    if (isUpstreamGone) {
-      if (branchName == 'master' ||
-          branchName == 'main' ||
-          branchName == defaultBranch) {
-        continue;
-      }
-      goneBranches[branchName] = sha;
+    if (branchName == 'master' ||
+        branchName == 'main' ||
+        branchName == defaultBranch) {
+      continue;
     }
+
+    if (isUpstreamGone) {
+      goneBranches[branchName] = sha;
+    } else if (upstream.isNotEmpty) {
+      activeRemoteBranches.add(branchName);
+    }
+  }
+
+  // Only check gh if we actually need to (either we have gone branches, or
+  // check is enabled).
+  final needGh =
+      goneBranches.isNotEmpty || (check && activeRemoteBranches.isNotEmpty);
+
+  final ghAvailable = needGh && await gitDir.isGitHubCliAvailable();
+  Map<String, ({String state, String url, int number})>? recentPrs;
+  if (ghAvailable) {
+    recentPrs = await gitDir.getRecentPrsInfo();
   }
 
   if (goneBranches.isEmpty) {
     print('No local branches found with deleted upstreams.');
-    return;
-  }
-
-  print(
-    styleDim.wrap(
-          'Checking safety of ${goneBranches.length} branches with '
-          'gone upstreams...',
-        ) ??
-        'Checking safety of ${goneBranches.length} branches with '
+  } else {
+    print(
+      styleDim.wrap(
+            'Checking safety of ${goneBranches.length} branches with '
             'gone upstreams...',
-  );
+          ) ??
+          'Checking safety of ${goneBranches.length} branches with '
+              'gone upstreams...',
+    );
 
-  final ghAvailable = await gitDir.isGitHubCliAvailable();
-  Map<String, String>? recentPrs;
-  if (ghAvailable) {
-    recentPrs = await gitDir.getRecentPrsState();
-  }
+    final toDelete = <String>[];
 
-  final toDelete = <String>[];
+    for (final entry in goneBranches.entries) {
+      final branch = entry.key;
+      final sha = entry.value;
 
-  for (final entry in goneBranches.entries) {
-    final branch = entry.key;
-    final sha = entry.value;
-
-    // Tier 1: Local Checks
-    if (await gitDir.isMergedInto(branch, defaultBranch)) {
-      toDelete.add(branch);
-      continue;
-    }
-
-    // Tier 2 & 3: GitHub Checks (if available)
-    if (ghAvailable) {
-      String? prState;
-      final prNumber = await gitDir.getLocalPrNumber(branch);
-      if (prNumber != null) {
-        prState = await gitDir.getPrStateByNumber(prNumber);
-      } else {
-        prState = recentPrs?[branch];
-        prState ??= await gitDir.getPrStateByBranch(branch);
-      }
-
-      if (prState == 'MERGED') {
-        // PR is merged, but we have unmerged local commits!
-        if (stdin.hasTerminal) {
-          stdout.write(
-            yellow.wrap(
-                  'Branch "$branch" has a merged PR but contains unmerged local commits. Delete anyway? [y/N]: ',
-                ) ??
-                'Branch "$branch" has a merged PR but contains unmerged local commits. Delete anyway? [y/N]: ',
-          );
-          final response = stdin.readLineSync()?.trim().toLowerCase();
-          if (response == 'y' || response == 'yes') {
-            toDelete.add(branch);
-          } else {
-            print(
-              styleDim.wrap('Skipping deletion of "$branch".') ??
-                  'Skipping deletion of "$branch".',
-            );
-          }
-        } else {
-          printError(
-            'Warning: Branch "$branch" has a merged PR but contains '
-            'unmerged local commits. Skipping deletion.',
-          );
-        }
+      // Tier 1: Local Checks
+      if (await gitDir.isMergedInto(branch, defaultBranch)) {
+        toDelete.add(branch);
         continue;
       }
+
+      // Tier 2 & 3: GitHub Checks (if available)
+      if (ghAvailable) {
+        String? prState;
+        final prNumber = await gitDir.getLocalPrNumber(branch);
+        if (prNumber != null) {
+          prState = await gitDir.getPrStateByNumber(prNumber);
+        } else {
+          prState = recentPrs?[branch]?.state;
+          prState ??= await gitDir.getPrStateByBranch(branch);
+        }
+
+        if (prState == 'MERGED') {
+          // PR is merged, but we have unmerged local commits!
+          if (stdin.hasTerminal) {
+            stdout.write(
+              yellow.wrap(
+                    'Branch "$branch" has a merged PR but contains unmerged local commits. Delete anyway? [y/N]: ',
+                  ) ??
+                  'Branch "$branch" has a merged PR but contains unmerged local commits. Delete anyway? [y/N]: ',
+            );
+            final response = stdin.readLineSync()?.trim().toLowerCase();
+            if (response == 'y' || response == 'yes') {
+              toDelete.add(branch);
+            } else {
+              print(
+                styleDim.wrap('Skipping deletion of "$branch".') ??
+                    'Skipping deletion of "$branch".',
+              );
+            }
+          } else {
+            printError(
+              'Warning: Branch "$branch" has a merged PR but contains '
+              'unmerged local commits. Skipping deletion.',
+            );
+          }
+          continue;
+        }
+      }
+
+      // If we reach here, it's not merged and not approved for deletion
+      printError(
+        'Warning: Branch "$branch" ($sha) has a gone upstream but contains '
+        'unmerged commits. Skipping deletion.',
+      );
     }
 
-    // If we reach here, it's not merged and not approved for deletion
-    printError(
-      'Warning: Branch "$branch" ($sha) has a gone upstream but contains '
-      'unmerged commits. Skipping deletion.',
-    );
+    if (toDelete.isNotEmpty) {
+      print('Found ${toDelete.length} branches to delete:');
+      for (final branch in toDelete) {
+        print('  $branch (${goneBranches[branch]})');
+      }
+
+      for (final branch in toDelete) {
+        print('Deleting $branch...');
+        try {
+          await gitDir.deleteBranch(branch, force: true);
+          print('  Done!');
+        } catch (e) {
+          printError('Failed to delete $branch: $e');
+        }
+      }
+    }
   }
 
-  if (toDelete.isEmpty) {
-    return;
-  }
+  // Check active remote branches for closed PRs (only if check is enabled!)
+  if (check) {
+    if (activeRemoteBranches.isEmpty) {
+      print('No active remote branches to check.');
+    } else if (ghAvailable && recentPrs != null) {
+      var headingPrinted = false;
 
-  print('Found ${toDelete.length} branches to delete:');
-  for (final branch in toDelete) {
-    print('  $branch (${goneBranches[branch]})');
-  }
+      for (final branch in activeRemoteBranches) {
+        // Optimize: Only check branches present in the cached recent PRs map.
+        // This avoids making slow, sequential network calls for old/unrelated branches.
+        final prInfo = recentPrs[branch];
 
-  for (final branch in toDelete) {
-    print('Deleting $branch...');
-    try {
-      await gitDir.deleteBranch(branch, force: true);
-      print('  Done!');
-    } catch (e) {
-      printError('Failed to delete $branch: $e');
+        if (prInfo != null &&
+            (prInfo.state == 'MERGED' || prInfo.state == 'CLOSED')) {
+          if (!headingPrinted) {
+            print('');
+            print(
+              styleDim.wrap(
+                    'Checking active remote branches for closed PRs...',
+                  ) ??
+                  'Checking active remote branches for closed PRs...',
+            );
+            headingPrinted = true;
+          }
+
+          final prLabel = '#${prInfo.number}';
+          final branchLabel = styleBold.wrap(branch) ?? branch;
+          final link = _hyperlink(prInfo.url, 'Click here');
+          print(
+            'PR $prLabel for branch "$branchLabel" is closed, '
+            'but the remote branch still exists.\n'
+            '  $link to delete it: ${prInfo.url}',
+          );
+        }
+      }
+    }
+  } else {
+    // Print a subtle tip to remind the user about the feature!
+    if (activeRemoteBranches.isNotEmpty) {
+      print(
+        styleDim.wrap(
+              'Tip: Run with --check to inspect active remote branches '
+              'for closed PRs.',
+            ) ??
+            'Tip: Run with --check to inspect active remote branches '
+                'for closed PRs.',
+      );
     }
   }
 }
+
+String _hyperlink(String url, String text) =>
+    '\x1B]8;;$url\x1B\\$text\x1B]8;;\x1B\\';
 
 /// Exception thrown by `git-up` operations.
 ///

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -200,24 +200,27 @@ void main() {
     },
   );
 
-  test('gitUp fails when working tree is dirty and conflicts', () async {
-    final filePath = p.join(localPath, 'conflict.txt');
+  test('gitUp fails immediately when working tree is dirty', () async {
+    final filePath = p.join(localPath, 'dirty.txt');
     File(filePath).writeAsStringSync('content A');
-    await localGitDir.runCommand(['add', 'conflict.txt']);
-    await localGitDir.runCommand(['commit', '-m', 'add conflict.txt']);
+    await localGitDir.runCommand(['add', 'dirty.txt']);
+    await localGitDir.runCommand(['commit', '-m', 'add dirty.txt']);
 
-    await localGitDir.runCommand(['checkout', '-b', 'feature']);
-
+    // Make it dirty
     File(filePath).writeAsStringSync('content B');
-    await localGitDir.runCommand(['add', 'conflict.txt']);
-    await localGitDir.runCommand(['commit', '-m', 'update conflict.txt']);
 
-    File(filePath).writeAsStringSync('content C');
-
-    await expectLater(
-      () => wrappedForTesting(() => gitUp(workingDirectory: localPath)),
-      throwsA(isA<GitUpException>()),
-    );
+    await expectLater(() async {
+      await expectLater(
+        () => wrappedForTesting(() => gitUp(workingDirectory: localPath)),
+        throwsA(
+          isA<GitUpException>().having(
+            (e) => e.message,
+            'message',
+            contains('Working tree is dirty.'),
+          ),
+        ),
+      );
+    }, prints(contains('Please commit or stash your changes and try again.')));
   });
 
   test('gitUp cleans up standard-merged gone branches', () async {
@@ -333,4 +336,54 @@ void main() {
       isNot(contains('feature-squash')),
     );
   });
+
+  test(
+    'getBranchesStatus returns correct upstream and isUpstreamGone',
+    () async {
+      // 1. Create a branch with no upstream
+      await localGitDir.runCommand(['checkout', '-b', 'branch-no-upstream']);
+
+      // 2. Create a branch with active upstream
+      await localGitDir.runCommand(['checkout', '-b', 'branch-with-upstream']);
+      await localGitDir.runCommand([
+        'push',
+        '-u',
+        'origin',
+        'branch-with-upstream',
+      ]);
+
+      // 3. Create a branch with gone upstream
+      await localGitDir.runCommand(['checkout', '-b', 'branch-gone-upstream']);
+      await localGitDir.runCommand([
+        'push',
+        '-u',
+        'origin',
+        'branch-gone-upstream',
+      ]);
+      final remoteGitDir = await GitDir.fromExisting(
+        p.join(d.sandbox, 'remote'),
+      );
+      await remoteGitDir.runCommand(['branch', '-D', 'branch-gone-upstream']);
+      await localGitDir.runCommand(['fetch', '--prune']);
+
+      final status = await localGitDir.getBranchesStatus();
+
+      final noUpstream = status['branch-no-upstream'];
+      expect(noUpstream, isNotNull);
+      expect(noUpstream!.upstream, isEmpty);
+      expect(noUpstream.isUpstreamGone, isFalse);
+
+      final withUpstream = status['branch-with-upstream'];
+      expect(withUpstream, isNotNull);
+      expect(
+        withUpstream!.upstream,
+        contains('refs/remotes/origin/branch-with-upstream'),
+      );
+      expect(withUpstream.isUpstreamGone, isFalse);
+
+      final goneUpstream = status['branch-gone-upstream'];
+      expect(goneUpstream, isNotNull);
+      expect(goneUpstream!.isUpstreamGone, isTrue);
+    },
+  );
 }

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -386,4 +386,46 @@ void main() {
       expect(goneUpstream!.isUpstreamGone, isTrue);
     },
   );
+
+  test(
+    'getBranchesStatus handles branch names containing pipe character',
+    () async {
+      const branchName = 'feature|pipe-branch';
+      await localGitDir.runCommand(['checkout', '-b', branchName]);
+      await localGitDir.runCommand(['push', '-u', 'origin', branchName]);
+
+      final status = await localGitDir.getBranchesStatus();
+      final branchStatus = status[branchName];
+      expect(branchStatus, isNotNull);
+      expect(
+        branchStatus!.upstream,
+        contains('refs/remotes/origin/$branchName'),
+      );
+      expect(branchStatus.isUpstreamGone, isFalse);
+    },
+  );
+
+  test('gitUp with check: true warns if GitHub CLI is unavailable', () async {
+    mockGhUnavailableForTesting = true;
+    addTearDown(() => mockGhUnavailableForTesting = false);
+
+    await localGitDir.runCommand(['checkout', '-b', 'feature-active']);
+    await localGitDir.runCommand(['push', '-u', 'origin', 'feature-active']);
+
+    await localGitDir.runCommand(['checkout', 'main']);
+
+    await expectLater(
+      () => wrappedForTesting(
+        () => gitUp(workingDirectory: localPath, check: true),
+      ),
+      prints(
+        allOf(
+          contains(
+            'Warning: GitHub CLI (gh) is not available or authenticated.',
+          ),
+          contains('Skipping active remote branch checks.'),
+        ),
+      ),
+    );
+  });
 }


### PR DESCRIPTION
Enhances `git-up` with the ability to check active remote branches for closed/merged PRs and suggest deleting them using clickable terminal hyperlinks. Also introduces an early dirty-tree abort to keep operations safe and clean.