### PR TITLE
feat: make git-up safety checks smarter with PR base branch matching and git merge-tree

### DIFF
--- a/lib/src/git_extensions.dart
+++ b/lib/src/git_extensions.dart
@@ -444,6 +444,22 @@ extension GitDirExtensions on GitDir {
       refs.add((localResult.stdout as String).trim());
     }
 
+    // Try all remote-tracking branches matching the name across all remotes
+    final remotesResult = await runCommand([
+      'for-each-ref',
+      '--format=%(refname)',
+      'refs/remotes/*/$branchName',
+    ], throwOnError: false);
+    if (remotesResult.exitCode == 0) {
+      final lines = LineSplitter.split(remotesResult.stdout as String);
+      for (final line in lines) {
+        final ref = line.trim();
+        if (ref.isNotEmpty) {
+          refs.add(ref);
+        }
+      }
+    }
+
     return refs.toList();
   }
 }

--- a/lib/src/git_extensions.dart
+++ b/lib/src/git_extensions.dart
@@ -3,7 +3,8 @@ import 'dart:io';
 import 'package:git/git.dart';
 
 bool mockGhUnavailableForTesting = false;
-Map<String, ({String state, String url, int number})>? mockRecentPrsForTesting;
+Map<String, ({String state, String url, int number, String baseBranch})>?
+mockRecentPrsForTesting;
 
 /// Extensions on [GitDir] to provide high-level operations used in this
 /// package.
@@ -181,7 +182,8 @@ extension GitDirExtensions on GitDir {
       return true;
     }
 
-    // 2. Tree history match check (fast squash-merge check)
+    // 2. Tree history match check (fast squash-merge check when no other
+    //    changes)
     try {
       final branchTreeResult = await runCommand([
         'rev-parse',
@@ -208,6 +210,35 @@ extension GitDirExtensions on GitDir {
       }
     } catch (_) {
       // Fallback to next check
+    }
+
+    // 3. Trial merge check (using git merge-tree)
+    // Merges branchName into targetBranch in-memory.
+    // If the merge is clean (exit code 0) and the resulting tree is identical
+    // to targetBranch's tree, then branchName introduces no new changes.
+    try {
+      final targetTreeResult = await runCommand([
+        'rev-parse',
+        '$targetBranch^{tree}',
+      ], throwOnError: false);
+      if (targetTreeResult.exitCode == 0) {
+        final targetTree = (targetTreeResult.stdout as String).trim();
+
+        final mergeTreeResult = await runCommand([
+          'merge-tree',
+          targetBranch,
+          branchName,
+        ], throwOnError: false);
+
+        if (mergeTreeResult.exitCode == 0) {
+          final mergeTree = (mergeTreeResult.stdout as String).trim();
+          if (mergeTree == targetTree) {
+            return true;
+          }
+        }
+      }
+    } catch (_) {
+      // Fallback to returning false
     }
 
     return false;
@@ -250,23 +281,27 @@ extension GitDirExtensions on GitDir {
     return int.tryParse(output);
   }
 
-  /// Queries the GitHub API for the state of a PR by its number.
+  /// Queries the GitHub API for the PR info by its number.
   ///
-  /// Returns the PR state (e.g. 'MERGED', 'CLOSED', 'OPEN') or null if not
-  /// found.
-  Future<String?> getPrStateByNumber(int prNumber) async {
+  /// Returns the PR state and base branch, or null if not found.
+  Future<({String state, String baseBranch})?> getPrInfoByNumber(
+    int prNumber,
+  ) async {
     try {
       final result = await Process.run('gh', [
         'pr',
         'view',
         prNumber.toString(),
         '--json',
-        'state',
+        'state,baseRefName',
       ]);
       if (result.exitCode == 0) {
         final data =
             jsonDecode(result.stdout as String) as Map<String, dynamic>;
-        return data['state'] as String?;
+        return (
+          state: data['state'] as String? ?? '',
+          baseBranch: data['baseRefName'] as String? ?? '',
+        );
       }
     } catch (_) {
       // Ignore and return null
@@ -274,23 +309,27 @@ extension GitDirExtensions on GitDir {
     return null;
   }
 
-  /// Queries the GitHub API for the state of a PR by branch name.
+  /// Queries the GitHub API for the PR info by branch name.
   ///
-  /// Returns the PR state (e.g. 'MERGED', 'CLOSED', 'OPEN') or null if not
-  /// found.
-  Future<String?> getPrStateByBranch(String branchName) async {
+  /// Returns the PR state and base branch, or null if not found.
+  Future<({String state, String baseBranch})?> getPrInfoByBranch(
+    String branchName,
+  ) async {
     try {
       final result = await Process.run('gh', [
         'pr',
         'view',
         branchName,
         '--json',
-        'state',
+        'state,baseRefName',
       ]);
       if (result.exitCode == 0) {
         final data =
             jsonDecode(result.stdout as String) as Map<String, dynamic>;
-        return data['state'] as String?;
+        return (
+          state: data['state'] as String? ?? '',
+          baseBranch: data['baseRefName'] as String? ?? '',
+        );
       }
     } catch (_) {
       // Ignore and return null
@@ -301,12 +340,15 @@ extension GitDirExtensions on GitDir {
   /// Retrieves the details of recent PRs in the repository.
   ///
   /// Returns a map of head branch names to their PR details.
-  Future<Map<String, ({String state, String url, int number})>>
+  Future<
+    Map<String, ({String state, String url, int number, String baseBranch})>
+  >
   getRecentPrsInfo({int limit = 100}) async {
     if (mockRecentPrsForTesting != null) {
       return mockRecentPrsForTesting!;
     }
-    final prs = <String, ({String state, String url, int number})>{};
+    final prs =
+        <String, ({String state, String url, int number, String baseBranch})>{};
     try {
       final result = await Process.run('gh', [
         'pr',
@@ -318,7 +360,7 @@ extension GitDirExtensions on GitDir {
         '--limit',
         limit.toString(),
         '--json',
-        'headRefName,state,url,number',
+        'headRefName,state,url,number,baseRefName',
       ]);
       if (result.exitCode == 0) {
         final list = jsonDecode(result.stdout as String) as List<dynamic>;
@@ -328,11 +370,18 @@ extension GitDirExtensions on GitDir {
             final state = item['state'] as String?;
             final url = item['url'] as String?;
             final number = item['number'] as int?;
+            final baseBranch = item['baseRefName'] as String?;
             if (head != null &&
                 state != null &&
                 url != null &&
-                number != null) {
-              prs[head] = (state: state, url: url, number: number);
+                number != null &&
+                baseBranch != null) {
+              prs[head] = (
+                state: state,
+                url: url,
+                number: number,
+                baseBranch: baseBranch,
+              );
             }
           }
         }
@@ -359,5 +408,36 @@ extension GitDirExtensions on GitDir {
     await runCommand(['config', 'user.email', 'test@test.com']);
     await runCommand(['config', 'user.name', 'Tester']);
     await runCommand(['config', 'core.autocrlf', 'false']);
+  }
+
+  /// Resolves the given [branchName] to its local ref and/or its upstream ref if
+  /// they exist.
+  ///
+  /// Returns a list of resolved full ref names (e.g.
+  /// ['refs/remotes/origin/main', 'refs/heads/main']).
+  Future<List<String>> resolveLookups(String branchName) async {
+    final refs = <String>[];
+
+    // Try upstream first (e.g. branchName@{u})
+    final upstreamResult = await runCommand([
+      'rev-parse',
+      '--symbolic-full-name',
+      '$branchName@{u}',
+    ], throwOnError: false);
+    if (upstreamResult.exitCode == 0) {
+      refs.add((upstreamResult.stdout as String).trim());
+    }
+
+    // Try local branch
+    final localResult = await runCommand([
+      'rev-parse',
+      '--symbolic-full-name',
+      branchName,
+    ], throwOnError: false);
+    if (localResult.exitCode == 0) {
+      refs.add((localResult.stdout as String).trim());
+    }
+
+    return refs;
   }
 }

--- a/lib/src/git_extensions.dart
+++ b/lib/src/git_extensions.dart
@@ -420,8 +420,8 @@ extension GitDirExtensions on GitDir {
   ///
   /// Returns a list of resolved full ref names (e.g.
   /// ['refs/remotes/origin/main', 'refs/heads/main']).
-  Future<List<String>> resolveLookups(String branchName) async {
-    if (branchName.isEmpty) return const [];
+  Future<Set<String>> resolveLookups(String branchName) async {
+    if (branchName.isEmpty) return const <String>{};
     final refs = <String>{};
 
     // Try upstream first (e.g. branchName@{u})
@@ -460,6 +460,6 @@ extension GitDirExtensions on GitDir {
       }
     }
 
-    return refs.toList();
+    return refs;
   }
 }

--- a/lib/src/git_extensions.dart
+++ b/lib/src/git_extensions.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:git/git.dart';
 
+bool mockGhAvailableForTesting = false;
 bool mockGhUnavailableForTesting = false;
 Map<String, ({String state, String url, int number, String baseBranch})>?
 mockRecentPrsForTesting;
@@ -226,6 +227,7 @@ extension GitDirExtensions on GitDir {
 
         final mergeTreeResult = await runCommand([
           'merge-tree',
+          '--write-tree',
           targetBranch,
           branchName,
         ], throwOnError: false);
@@ -246,6 +248,9 @@ extension GitDirExtensions on GitDir {
 
   /// Checks if the `gh` CLI is available and authenticated.
   Future<bool> isGitHubCliAvailable() async {
+    if (mockGhAvailableForTesting) {
+      return true;
+    }
     if (mockGhUnavailableForTesting) {
       return false;
     }
@@ -416,7 +421,8 @@ extension GitDirExtensions on GitDir {
   /// Returns a list of resolved full ref names (e.g.
   /// ['refs/remotes/origin/main', 'refs/heads/main']).
   Future<List<String>> resolveLookups(String branchName) async {
-    final refs = <String>[];
+    if (branchName.isEmpty) return const [];
+    final refs = <String>{};
 
     // Try upstream first (e.g. branchName@{u})
     final upstreamResult = await runCommand([
@@ -438,6 +444,6 @@ extension GitDirExtensions on GitDir {
       refs.add((localResult.stdout as String).trim());
     }
 
-    return refs;
+    return refs.toList();
   }
 }

--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -346,7 +346,9 @@ Future<void> _cleanBranches(
         }
       }
 
-      final targetBranch = baseBranch ?? defaultBranch;
+      final targetBranch = (baseBranch != null && baseBranch.isNotEmpty)
+          ? baseBranch
+          : defaultBranch;
 
       // Resolve lookups for the target branch (e.g. targetBranch@{u} and
       // targetBranch)

--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -286,7 +286,8 @@ Future<void> _cleanBranches(
   final needGh = goneBranches.isNotEmpty || activeRemoteBranches.isNotEmpty;
 
   final ghAvailable = needGh && await gitDir.isGitHubCliAvailable();
-  Map<String, ({String state, String url, int number})>? recentPrs;
+  Map<String, ({String state, String url, int number, String baseBranch})>?
+  recentPrs;
   if (ghAvailable) {
     recentPrs = await gitDir.getRecentPrsInfo();
 
@@ -322,32 +323,63 @@ Future<void> _cleanBranches(
       final branch = entry.key;
       final sha = entry.value;
 
-      // Tier 1: Local Checks
-      if (await gitDir.isMergedInto(branch, defaultBranch)) {
+      // Determine the PR info first if GH is available, so we know the target
+      // base branch!
+      String? prState;
+      String? baseBranch;
+      if (ghAvailable) {
+        final prNumber = await gitDir.getLocalPrNumber(branch);
+        if (prNumber != null) {
+          final prInfo = await gitDir.getPrInfoByNumber(prNumber);
+          prState = prInfo?.state;
+          baseBranch = prInfo?.baseBranch;
+        } else {
+          final cachedPr = recentPrs?[branch];
+          if (cachedPr != null) {
+            prState = cachedPr.state;
+            baseBranch = cachedPr.baseBranch;
+          } else {
+            final prInfo = await gitDir.getPrInfoByBranch(branch);
+            prState = prInfo?.state;
+            baseBranch = prInfo?.baseBranch;
+          }
+        }
+      }
+
+      final targetBranch = baseBranch ?? defaultBranch;
+
+      // Resolve lookups for the target branch (e.g. targetBranch@{u} and
+      // targetBranch)
+      final targetRefs = await gitDir.resolveLookups(targetBranch);
+      if (targetRefs.isEmpty) {
+        // If we can't resolve targetRefs (e.g. base branch doesn't exist locally/remotely),
+        // fallback to using targetBranch as-is (which will likely fail safely).
+        targetRefs.add(targetBranch);
+      }
+
+      // Check if merged into ANY of the target refs
+      var isMerged = false;
+      for (final ref in targetRefs) {
+        if (await gitDir.isMergedInto(branch, ref)) {
+          isMerged = true;
+          break;
+        }
+      }
+
+      if (isMerged) {
         toDelete.add(branch);
         continue;
       }
 
       // Tier 2 & 3: GitHub Checks (if available)
       if (ghAvailable) {
-        String? prState;
-        final prNumber = await gitDir.getLocalPrNumber(branch);
-        if (prNumber != null) {
-          prState = await gitDir.getPrStateByNumber(prNumber);
-        } else {
-          prState = recentPrs?[branch]?.state;
-          prState ??= await gitDir.getPrStateByBranch(branch);
-        }
-
         if (prState == 'MERGED') {
           // PR is merged, but we have unmerged local commits!
           if (stdin.hasTerminal) {
-            stdout.write(
-              yellow.wrap(
-                    'Branch "$branch" has a merged PR but contains unmerged local commits. Delete anyway? [y/N]: ',
-                  ) ??
-                  'Branch "$branch" has a merged PR but contains unmerged local commits. Delete anyway? [y/N]: ',
-            );
+            final prompt =
+                'Branch "$branch" has a merged PR but contains unmerged '
+                'local commits (relative to $targetBranch). Delete anyway? [y/N]: ';
+            stdout.write(yellow.wrap(prompt) ?? prompt);
             final response = stdin.readLineSync()?.trim().toLowerCase();
             if (response == 'y' || response == 'yes') {
               toDelete.add(branch);
@@ -360,7 +392,8 @@ Future<void> _cleanBranches(
           } else {
             printError(
               'Warning: Branch "$branch" has a merged PR but contains '
-              'unmerged local commits. Skipping deletion.',
+              'unmerged local commits (relative to $targetBranch). '
+              'Skipping deletion.',
             );
           }
           continue;
@@ -370,7 +403,7 @@ Future<void> _cleanBranches(
       // If we reach here, it's not merged and not approved for deletion
       printError(
         'Warning: Branch "$branch" ($sha) has a gone upstream but contains '
-        'unmerged commits. Skipping deletion.',
+        'unmerged commits (relative to $targetBranch). Skipping deletion.',
       );
     }
 

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -282,7 +282,8 @@ void main() {
           contains('Checking safety of 1 branches with gone upstreams...'),
           contains(
             'Warning: Branch "feature-unmerged" ($sha) has a gone upstream '
-            'but contains unmerged commits. Skipping deletion.',
+            'but contains unmerged commits (relative to main). '
+            'Skipping deletion.',
           ),
         ),
       ),
@@ -336,6 +337,87 @@ void main() {
       isNot(contains('feature-squash')),
     );
   });
+
+  test(
+    'gitUp cleans up squash-merged gone branches even when main has progressed',
+    () async {
+      // 1. Create and commit to feature-squash-progressed
+      await localGitDir.runCommand([
+        'checkout',
+        '-b',
+        'feature-squash-progressed',
+      ]);
+      final filePath = p.join(localPath, 'squash_prog.txt');
+      File(filePath).writeAsStringSync('squash progressed content');
+      await localGitDir.runCommand(['add', 'squash_prog.txt']);
+      await localGitDir.runCommand([
+        'commit',
+        '-m',
+        'Squash progressed commit',
+      ]);
+
+      // 2. Push to remote
+      await localGitDir.runCommand([
+        'push',
+        '-u',
+        'origin',
+        'feature-squash-progressed',
+      ]);
+
+      // 3. Switch to main
+      await localGitDir.runCommand(['checkout', 'main']);
+
+      // 4. Simulate an unrelated commit on remote main
+      final remoteGitDir = await GitDir.fromExisting(
+        p.join(d.sandbox, 'remote'),
+      );
+      final remoteUnrelatedPath = p.join(d.sandbox, 'remote', 'unrelated.txt');
+      File(remoteUnrelatedPath).writeAsStringSync('unrelated content');
+      await remoteGitDir.runCommand(['add', 'unrelated.txt']);
+      await remoteGitDir.runCommand([
+        'commit',
+        '-m',
+        'Unrelated commit on main',
+      ]);
+
+      // 5. Simulate squash merge on remote main
+      final remoteFilePath = p.join(d.sandbox, 'remote', 'squash_prog.txt');
+      File(remoteFilePath).writeAsStringSync('squash progressed content');
+      await remoteGitDir.runCommand(['add', 'squash_prog.txt']);
+      await remoteGitDir.runCommand([
+        'commit',
+        '-m',
+        'Squashed PR progressed commit (#2)',
+      ]);
+
+      // 6. Delete remote branch feature-squash-progressed
+      await remoteGitDir.runCommand([
+        'branch',
+        '-D',
+        'feature-squash-progressed',
+      ]);
+
+      // 7. Run gitUp - should pull squashed main (with both commits) and
+      //    clean up feature-squash-progressed
+      await expectLater(
+        () => wrappedForTesting(() => gitUp(workingDirectory: localPath)),
+        prints(
+          allOf(
+            contains('Successfully updated main.'),
+            contains('Checking safety of 1 branches with gone upstreams...'),
+            contains('Deleting feature-squash-progressed...'),
+          ),
+        ),
+      );
+
+      // Verify it was deleted
+      final branches = await localGitDir.branches();
+      expect(
+        branches.map((b) => b.branchName),
+        isNot(contains('feature-squash-progressed')),
+      );
+    },
+  );
 
   test(
     'getBranchesStatus returns correct upstream and isUpstreamGone',
@@ -436,6 +518,7 @@ void main() {
         state: 'CLOSED',
         url: 'https://github.com/kevmoo/scripts/pull/123',
         number: 123,
+        baseBranch: 'main',
       ),
     };
     addTearDown(() {
@@ -470,6 +553,7 @@ void main() {
           state: 'CLOSED',
           url: 'https://github.com/kevmoo/scripts/pull/123',
           number: 123,
+          baseBranch: 'main',
         ),
       };
       addTearDown(() {
@@ -517,6 +601,7 @@ void main() {
         state: 'MERGED',
         url: 'https://github.com/kevmoo/scripts/pull/123',
         number: 123,
+        baseBranch: 'main',
       ),
     };
     addTearDown(() {
@@ -555,4 +640,87 @@ void main() {
       isNot(contains('feature-merged-active')),
     );
   });
+
+  test(
+    'gitUp cleans up gone branches merged into a non-default branch',
+    () async {
+      mockGhUnavailableForTesting = false;
+      mockRecentPrsForTesting = {
+        'feature-merged-non-default': (
+          state: 'MERGED',
+          url: 'https://github.com/kevmoo/scripts/pull/124',
+          number: 124,
+          baseBranch: 'feature-base',
+        ),
+      };
+      addTearDown(() {
+        mockRecentPrsForTesting = null;
+      });
+
+      // 1. Create the base branch 'feature-base'
+      await localGitDir.runCommand(['checkout', '-b', 'feature-base']);
+      await localGitDir.runCommand(['push', '-u', 'origin', 'feature-base']);
+
+      // 2. Create the feature branch 'feature-merged-non-default' from
+      //    'feature-base'
+      await localGitDir.runCommand([
+        'checkout',
+        '-b',
+        'feature-merged-non-default',
+      ]);
+      final filePath = p.join(localPath, 'feature.txt');
+      File(filePath).writeAsStringSync('feature content');
+      await localGitDir.runCommand(['add', 'feature.txt']);
+      await localGitDir.runCommand(['commit', '-m', 'Feature commit']);
+
+      // 3. Push feature branch
+      await localGitDir.runCommand([
+        'push',
+        '-u',
+        'origin',
+        'feature-merged-non-default',
+      ]);
+
+      // 4. Switch back to main
+      await localGitDir.runCommand(['checkout', 'main']);
+
+      // 5. Simulate merge of feature branch into 'feature-base' on remote
+      final remoteGitDir = await GitDir.fromExisting(
+        p.join(d.sandbox, 'remote'),
+      );
+      await remoteGitDir.runCommand(['checkout', 'feature-base']);
+      final remoteFilePath = p.join(d.sandbox, 'remote', 'feature.txt');
+      File(remoteFilePath).writeAsStringSync('feature content');
+      await remoteGitDir.runCommand(['add', 'feature.txt']);
+      await remoteGitDir.runCommand(['commit', '-m', 'Merged feature (#124)']);
+
+      // 6. Delete remote feature branch
+      await remoteGitDir.runCommand([
+        'branch',
+        '-D',
+        'feature-merged-non-default',
+      ]);
+
+      // 7. Run gitUp - should fetch and prune, then detect that
+      //    feature-merged-non-default is merged into origin/feature-base
+      //    (since we resolve lookups and check origin/feature-base!).
+      //    It should delete feature-merged-non-default silently.
+      await expectLater(
+        () => wrappedForTesting(() => gitUp(workingDirectory: localPath)),
+        prints(
+          allOf(
+            contains('Checking safety of 1 branches with gone upstreams...'),
+            contains('Deleting feature-merged-non-default...'),
+          ),
+        ),
+      );
+
+      // Verify it was deleted
+      final branches = await localGitDir.branches();
+      expect(
+        branches.map((b) => b.branchName),
+        isNot(contains('feature-merged-non-default')),
+      );
+    },
+  );
 }

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -735,7 +735,7 @@ void main() {
     },
   );
 
-  test('resolveLookups returns empty list when branchName is empty', () async {
+  test('resolveLookups returns empty set when branchName is empty', () async {
     final refs = await localGitDir.resolveLookups('');
     expect(refs, isEmpty);
   });

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -512,6 +512,7 @@ void main() {
   });
 
   test('gitUp with check: true warns if remote branch still exists', () async {
+    mockGhAvailableForTesting = true;
     mockGhUnavailableForTesting = false;
     mockRecentPrsForTesting = {
       'feature-check': (
@@ -522,6 +523,7 @@ void main() {
       ),
     };
     addTearDown(() {
+      mockGhAvailableForTesting = false;
       mockRecentPrsForTesting = null;
     });
 
@@ -547,6 +549,7 @@ void main() {
   test(
     'gitUp with check: true does NOT warn if remote branch is deleted/pruned',
     () async {
+      mockGhAvailableForTesting = true;
       mockGhUnavailableForTesting = false;
       mockRecentPrsForTesting = {
         'feature-check-deleted': (
@@ -557,6 +560,7 @@ void main() {
         ),
       };
       addTearDown(() {
+        mockGhAvailableForTesting = false;
         mockRecentPrsForTesting = null;
       });
 
@@ -595,6 +599,7 @@ void main() {
 
   test('gitUp cleans up local branches that have merged PRs '
       'even if their upstream is not gone', () async {
+    mockGhAvailableForTesting = true;
     mockGhUnavailableForTesting = false;
     mockRecentPrsForTesting = {
       'feature-merged-active': (
@@ -605,6 +610,7 @@ void main() {
       ),
     };
     addTearDown(() {
+      mockGhAvailableForTesting = false;
       mockRecentPrsForTesting = null;
     });
 
@@ -644,6 +650,7 @@ void main() {
   test(
     'gitUp cleans up gone branches merged into a non-default branch',
     () async {
+      mockGhAvailableForTesting = true;
       mockGhUnavailableForTesting = false;
       mockRecentPrsForTesting = {
         'feature-merged-non-default': (
@@ -654,6 +661,7 @@ void main() {
         ),
       };
       addTearDown(() {
+        mockGhAvailableForTesting = false;
         mockRecentPrsForTesting = null;
       });
 
@@ -720,6 +728,84 @@ void main() {
       expect(
         branches.map((b) => b.branchName),
         isNot(contains('feature-merged-non-default')),
+      );
+    },
+  );
+
+  test('resolveLookups returns empty list when branchName is empty', () async {
+    final refs = await localGitDir.resolveLookups('');
+    expect(refs, isEmpty);
+  });
+
+  test(
+    'gitUp falls back to default branch when PR baseBranch is empty',
+    () async {
+      mockGhAvailableForTesting = true;
+      mockGhUnavailableForTesting = false;
+      mockRecentPrsForTesting = {
+        'feature-empty-base': (
+          state: 'MERGED',
+          url: 'https://github.com/kevmoo/scripts/pull/125',
+          number: 125,
+          baseBranch: '', // Empty base branch!
+        ),
+      };
+      addTearDown(() {
+        mockGhAvailableForTesting = false;
+        mockRecentPrsForTesting = null;
+      });
+
+      // 1. Create and commit to feature-empty-base
+      await localGitDir.runCommand(['checkout', '-b', 'feature-empty-base']);
+      final filePath = p.join(localPath, 'empty_base.txt');
+      File(filePath).writeAsStringSync('empty base content');
+      await localGitDir.runCommand(['add', 'empty_base.txt']);
+      await localGitDir.runCommand(['commit', '-m', 'Empty base commit']);
+
+      // 2. Push to remote
+      await localGitDir.runCommand([
+        'push',
+        '-u',
+        'origin',
+        'feature-empty-base',
+      ]);
+
+      // 3. Switch to main
+      await localGitDir.runCommand(['checkout', 'main']);
+
+      // 4. Simulate squash merge on remote main
+      final remoteGitDir = await GitDir.fromExisting(
+        p.join(d.sandbox, 'remote'),
+      );
+      final remoteFilePath = p.join(d.sandbox, 'remote', 'empty_base.txt');
+      File(remoteFilePath).writeAsStringSync('empty base content');
+      await remoteGitDir.runCommand(['add', 'empty_base.txt']);
+      await remoteGitDir.runCommand([
+        'commit',
+        '-m',
+        'Squashed PR empty base commit (#125)',
+      ]);
+
+      // 5. Delete remote branch feature-empty-base
+      await remoteGitDir.runCommand(['branch', '-D', 'feature-empty-base']);
+
+      // 6. Run gitUp - should fall back to main and clean up feature-empty-base
+      await expectLater(
+        () => wrappedForTesting(() => gitUp(workingDirectory: localPath)),
+        prints(
+          allOf(
+            contains('Successfully updated main.'),
+            contains('Checking safety of 1 branches with gone upstreams...'),
+            contains('Deleting feature-empty-base...'),
+          ),
+        ),
+      );
+
+      // Verify it was deleted
+      final branches = await localGitDir.branches();
+      expect(
+        branches.map((b) => b.branchName),
+        isNot(contains('feature-empty-base')),
       );
     },
   );

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -692,6 +692,9 @@ void main() {
       // 4. Switch back to main
       await localGitDir.runCommand(['checkout', 'main']);
 
+      // Delete the local base branch so it ONLY exists as origin/feature-base remote-tracking!
+      await localGitDir.runCommand(['branch', '-D', 'feature-base']);
+
       // 5. Simulate merge of feature branch into 'feature-base' on remote
       final remoteGitDir = await GitDir.fromExisting(
         p.join(d.sandbox, 'remote'),


### PR DESCRIPTION
This PR makes the `git up` branch safety checks significantly smarter and more robust by:

1. **Target-Branch Awareness:** Querying GitHub CLI (`gh`) for the PR's target base branch (`baseRefName`, e.g. `bazel`) and checking safety against it instead of always assuming `main`.
2. **Resilient Ref Resolution:** Resolving the target branch to both its local branch ref and its remote-tracking ref (e.g. `refs/remotes/origin/bazel`), ensuring we check against the most up-to-date remote state (updated during fetch) even if the local branch is stale.
3. **Trial Merges (`git merge-tree`):** Using in-memory trial merges to reliably detect squash-merged or cherry-picked branches when the target branch has progressed.
4. **Testing:** Adding comprehensive integration tests for squash-merged branches with progressed history and non-default target branches.