### PR TITLE
feat: implement git-up.before pre-update hook and refactor hook execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Safely switch to and update the default branch of a Git repository.
 git-up [--verbose | -v] [--help | -h]
 ```
 
+**Pre-Update Hook (`git-up.before`):**
+
+You can configure a custom shell command that runs automatically before `git-up` starts updating the repository (right after the dirty-tree safety check). This is useful for renewing credentials (e.g., running `gcert` on the Dart SDK) or preparing the environment.
+
+* **Local configuration** (runs only for the current repository):
+  ```shell
+  git config git-up.before "gcert"
+  ```
+
+* **Global configuration** (runs for all repositories where you run `git-up`):
+  ```shell
+  git config --global git-up.before "gcert"
+  ```
+
+If the before-command returns a non-zero exit code, `git-up` will abort immediately and exit with that same exit code, preventing any branches from being updated.
+
 **Post-Update Hook (`git-up.post`):**
 
 You can configure a custom shell command that runs automatically after `git-up` successfully updates the repository. This is useful for triggering automated builds, running package installations (e.g., `dart pub get`), running code generation, or starting workspace bootstraps.

--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -32,7 +32,7 @@ Future<void> gitUp({String? workingDirectory, bool check = false}) async {
     throw GitUpException('Working tree is dirty.');
   }
 
-  await _runHookCommand(gitDir, configKey: 'git-up.before', hookName: 'before');
+  await _runHookCommand(gitDir, configKey: 'git-up.before', hookName: 'Before');
 
   // 1. Determine Default Branch
   final defaultBranch = await getDefaultBranch(gitDir);
@@ -69,7 +69,7 @@ Future<void> gitUp({String? workingDirectory, bool check = false}) async {
 
   await _cleanBranches(gitDir, defaultBranch, check: check);
 
-  await _runHookCommand(gitDir, configKey: 'git-up.post', hookName: 'post');
+  await _runHookCommand(gitDir, configKey: 'git-up.post', hookName: 'Post');
 }
 
 Future<void> _runGit(
@@ -230,8 +230,8 @@ Future<void> _runHookCommand(
   }
 
   print(
-    styleDim.wrap('Running $hookName-command: $command') ??
-        'Running $hookName-command: $command',
+    styleDim.wrap('Running ${hookName.toLowerCase()}-command: $command') ??
+        'Running ${hookName.toLowerCase()}-command: $command',
   );
 
   final shell = Platform.isWindows ? 'cmd.exe' : 'sh';
@@ -247,7 +247,7 @@ Future<void> _runHookCommand(
   final exitCode = await process.exitCode;
   if (exitCode != 0) {
     throw GitUpException(
-      '${hookName[0].toUpperCase()}${hookName.substring(1)}-command '
+      '$hookName-command '
       'failed with exit code $exitCode: $command',
       exitCode: exitCode,
     );

--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -32,6 +32,8 @@ Future<void> gitUp({String? workingDirectory, bool check = false}) async {
     throw GitUpException('Working tree is dirty.');
   }
 
+  await _runHookCommand(gitDir, configKey: 'git-up.before', hookName: 'before');
+
   // 1. Determine Default Branch
   final defaultBranch = await getDefaultBranch(gitDir);
 
@@ -67,7 +69,7 @@ Future<void> gitUp({String? workingDirectory, bool check = false}) async {
 
   await _cleanBranches(gitDir, defaultBranch, check: check);
 
-  await _runPostCommand(gitDir);
+  await _runHookCommand(gitDir, configKey: 'git-up.post', hookName: 'post');
 }
 
 Future<void> _runGit(
@@ -207,11 +209,15 @@ void _printUpstreamFixSuggestion(String defaultBranch) {
   );
 }
 
-Future<void> _runPostCommand(GitDir gitDir) async {
+Future<void> _runHookCommand(
+  GitDir gitDir, {
+  required String configKey,
+  required String hookName,
+}) async {
   final configResult = await gitDir.runCommand([
     'config',
     '--get',
-    'git-up.post',
+    configKey,
   ], throwOnError: false);
 
   if (configResult.exitCode != 0) {
@@ -224,8 +230,8 @@ Future<void> _runPostCommand(GitDir gitDir) async {
   }
 
   print(
-    styleDim.wrap('Running post-command: $command') ??
-        'Running post-command: $command',
+    styleDim.wrap('Running $hookName-command: $command') ??
+        'Running $hookName-command: $command',
   );
 
   final shell = Platform.isWindows ? 'cmd.exe' : 'sh';
@@ -241,7 +247,8 @@ Future<void> _runPostCommand(GitDir gitDir) async {
   final exitCode = await process.exitCode;
   if (exitCode != 0) {
     throw GitUpException(
-      'Post-command failed with exit code $exitCode: $command',
+      '${hookName[0].toUpperCase()}${hookName.substring(1)}-command '
+      'failed with exit code $exitCode: $command',
       exitCode: exitCode,
     );
   }

--- a/test/git_up_test.dart
+++ b/test/git_up_test.dart
@@ -112,6 +112,63 @@ void main() {
     );
   });
 
+  test('Success case with git-up.before hook', () async {
+    final defaultBranch = await getDefaultBranch(localGitDir);
+    await localGitDir.runCommand([
+      'config',
+      'git-up.before',
+      'echo before_run>before_out.txt',
+    ]);
+
+    await expectLater(
+      () async {
+        final exitCode = await wrappedForTesting(
+          () => gitUp(workingDirectory: localPath),
+        );
+        expect(exitCode, 0);
+      },
+      prints(
+        allOf(
+          contains('Running before-command: echo before_run>before_out.txt'),
+          contains('Default branch: $defaultBranch'),
+          contains('Successfully updated $defaultBranch.'),
+        ),
+      ),
+    );
+
+    final file = File(p.join(localPath, 'before_out.txt'));
+    expect(file.existsSync(), isTrue);
+    expect(file.readAsStringSync().trim(), 'before_run');
+  });
+
+  test('Failure case with failing git-up.before hook', () async {
+    await localGitDir.runCommand(['config', 'git-up.before', 'exit 42']);
+
+    await expectLater(
+      () async {
+        await expectLater(
+          () => wrappedForTesting(() => gitUp(workingDirectory: localPath)),
+          throwsA(
+            isA<GitUpException>()
+                .having((e) => e.exitCode, 'exitCode', 42)
+                .having(
+                  (e) => e.message,
+                  'message',
+                  contains('Before-command failed with exit code 42: exit 42'),
+                ),
+          ),
+        );
+      },
+      prints(
+        allOf(
+          contains('Running before-command: exit 42'),
+          isNot(contains('Default branch:')),
+          isNot(contains('Successfully updated')),
+        ),
+      ),
+    );
+  });
+
   test('getDefaultBranch fails when origin/HEAD is missing', () async {
     // Delete origin/HEAD in the clone
     await localGitDir.runCommand(['remote', 'set-head', 'origin', '-d']);


### PR DESCRIPTION
This PR adds support for a new pre-update hook (`git-up.before`) in the `git-up` tool.

### Changes
1. **Pre-Update Hook (`git-up.before`)**:
   - Executes custom commands (e.g. `gcert` in the Dart SDK) at the start of the `gitUp` command, right after checking if the working tree is dirty.
   - If the pre-update command fails, the tool safely aborts early to prevent any changes or network requests.
2. **DRY Hook Execution Refactoring**:
   - Consolidated the duplicate execution and error handling logic for hooks into a reusable helper function `_runHookCommand` in `lib/src/git_up.dart`.
3. **Unit Tests**:
   - Added two new unit tests in `test/git_up_test.dart` for the success and failure cases of the new hook.
4. **Documentation**:
   - Fully documented the new hook, along with configuration examples, in `README.md`.