### PR TITLE
fix(git-up): remove unused sha parameter in helper

### DIFF
--- a/lib/src/git_up.dart
+++ b/lib/src/git_up.dart
@@ -401,7 +401,7 @@ class _CleanBranchesRunner(
     }
 
     if (_ghAvailable && prState == 'MERGED') {
-      return _evaluateMergedPrWithLocalCommits(branch, sha, headRefOid);
+      return _evaluateMergedPrWithLocalCommits(branch, headRefOid);
     }
 
     printError(
@@ -413,7 +413,6 @@ class _CleanBranchesRunner(
 
   Future<bool> _evaluateMergedPrWithLocalCommits(
     String branch,
-    String sha,
     String? headRefOid,
   ) async {
     final hasNewCommits =


### PR DESCRIPTION
Address code review feedback by removing an unreferenced sha parameter from the _evaluateMergedPrWithLocalCommits helper method inside _CleanBranchesRunner.
