### PR TITLE
ci: add automated cognitive complexity audit workflow

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -1,0 +1,24 @@
+name: Cognitive Complexity Audit
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Codebase
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Run Complexity Scanner
+        uses: kevmoo/cognitive_complexity.dart@main
+        with:
+          diff-base: origin/${{ github.base_ref }}
+          fail-threshold: 15
+          fail-on-increase: true


### PR DESCRIPTION
Integrate automated cognitive complexity evaluation into continuous integration checks using the composite action from kevmoo/cognitive_complexity.dart.

- Execute on all pull requests targeting main with git commit history depth preserved.
- Enforce production logic complexity ceiling (score <= 15) and fail CI on any complexity increase.
