### PR TITLE
refactor: systematically reduce cognitive complexity below threshold

### DIFF
--- a/lib/src/dart_clean.dart
+++ b/lib/src/dart_clean.dart
@@ -21,31 +21,17 @@ Future<void> runDartClean(DartCleanOptions options) async {
 
   final currentPid = pid;
 
-  Iterable<int> parsePgrepOutput(String output) =>
-      LineSplitter.split(output).where((s) => s.isNotEmpty).map(int.parse);
-
   // Find all dart processes
   final pids = <int>{};
   for (final exe in ['dart', 'dartvm']) {
-    try {
-      final output = await runProcess('pgrep', [exe]);
-      pids.addAll(parsePgrepOutput(output));
-    } on ProcessException catch (e) {
-      if (e.errorCode != 1) rethrow;
-    }
+    pids.addAll(await _findPids([exe]));
   }
 
   // Get current process children so we don't kill them
-  final protectedPids = {currentPid};
-  try {
-    final childrenOutput = await runProcess('pgrep', [
-      '-P',
-      currentPid.toString(),
-    ]);
-    protectedPids.addAll(parsePgrepOutput(childrenOutput));
-  } on ProcessException catch (e) {
-    if (e.errorCode != 1) rethrow;
-  }
+  final protectedPids = {
+    currentPid,
+    ...await _findPids(['-P', currentPid.toString()]),
+  };
 
   print('Checking ${pids.length} processes...');
 
@@ -80,17 +66,35 @@ Future<void> runDartClean(DartCleanOptions options) async {
 
   if (options.list) return;
 
-  if (options.force) {
+  await _handleKill(orphanedPids, force: options.force);
+}
+
+Future<List<int>> _findPids(List<String> args) async {
+  try {
+    final output = await runProcess('pgrep', args);
+    return LineSplitter.split(output)
+        .where((s) => s.isNotEmpty)
+        .map(int.parse)
+        .toList();
+  } on ProcessException catch (e) {
+    if (e.errorCode != 1) rethrow;
+    return const [];
+  }
+}
+
+Future<void> _handleKill(List<int> orphanedPids, {required bool force}) async {
+  if (force) {
     await killPids(orphanedPids, force: true);
+    return;
+  }
+
+  print('');
+  stdout.write('Kill all orphaned processes? (y/N) ');
+  final response = stdin.readLineSync();
+  if (response?.toLowerCase() == 'y') {
+    await killPids(orphanedPids);
   } else {
-    print('');
-    stdout.write('Kill all orphaned processes? (y/N) ');
-    final response = stdin.readLineSync();
-    if (response?.toLowerCase() == 'y') {
-      await killPids(orphanedPids);
-    } else {
-      print('Skipping kill.');
-    }
+    print('Skipping kill.');
   }
 }
 
@@ -159,43 +163,11 @@ class DartProcess({
 
 Future<DartProcess?> _checkProcess(int p, Set<int> protectedPids) async {
   if (protectedPids.contains(p)) {
-    final cmdline = formatCmdline(await getProcessCmdline(p));
-    final cwd = await getProcessCwd(p);
-
-    final treeResult = await Process.run('witr', [
-      '--pid',
-      p.toString(),
-      '--tree',
-      '--json',
-    ]);
-
-    var ancestry = <({int pid, String command})>[];
-    if (treeResult.exitCode == 0 || treeResult.stdout.toString().isNotEmpty) {
-      try {
-        final treeOutput = treeResult.stdout as String;
-        final treeData = jsonDecode(treeOutput) as Map<String, dynamic>;
-        final ancestryJson = treeData['Ancestry'] as List<dynamic>;
-        ancestry = ancestryJson.map((e) {
-          final map = e as Map<String, dynamic>;
-          return (pid: map['PID'] as int, command: map['Command'] as String);
-        }).toList();
-      } catch (e) {
-        // Ignore
-      }
-    }
-
-    return DartProcess(
-      pid: p,
-      cmdline: cmdline,
-      cwd: cwd,
-      reason: 'since it is a protected process (current script or child).',
-      ancestry: ancestry,
-    );
+    return _checkProtectedProcess(p);
   }
 
   try {
     final result = await Process.run('witr', ['--pid', p.toString(), '--json']);
-
     final witrOutput = result.stdout as String;
 
     if (witrOutput.trim().isEmpty && result.exitCode != 0) {
@@ -219,31 +191,10 @@ Future<DartProcess?> _checkProcess(int p, Set<int> protectedPids) async {
     final ppid = data.process.ppid;
     final parentName = ppid != null ? await getProcessName(ppid) : '<unknown>';
 
-    var reason = '';
-    int? ownerPid;
-    if (ppid != 1) {
-      reason = '';
-    } else {
-      final vscodePidStr = data.process.env
-          ?.where((String e) => e.startsWith('VSCODE_PID='))
-          .firstOrNull;
-
-      if (vscodePidStr != null) {
-        final vscodePid = int.tryParse(vscodePidStr.split('=')[1]);
-        if (vscodePid != null) {
-          if (await isProcessRunning(vscodePid)) {
-            reason =
-                'parent is launchd, but since VS Code '
-                '(PID $vscodePid) is running.';
-            ownerPid = vscodePid;
-          }
-        }
-      }
-
-      if (reason.isEmpty) {
-        reason = 'Orphaned';
-      }
-    }
+    final (:reason, :ownerPid) = await _resolveOwnerReason(
+      ppid,
+      data.process.env,
+    );
 
     final cwdEnv = data.process.env
         ?.where((String e) => e.startsWith('PWD='))
@@ -276,6 +227,70 @@ Future<DartProcess?> _checkProcess(int p, Set<int> protectedPids) async {
   }
 }
 
+Future<DartProcess> _checkProtectedProcess(int p) async {
+  final cmdline = formatCmdline(await getProcessCmdline(p));
+  final cwd = await getProcessCwd(p);
+
+  final treeResult = await Process.run('witr', [
+    '--pid',
+    p.toString(),
+    '--tree',
+    '--json',
+  ]);
+
+  var ancestry = <({int pid, String command})>[];
+  if (treeResult.exitCode == 0 || treeResult.stdout.toString().isNotEmpty) {
+    try {
+      final treeOutput = treeResult.stdout as String;
+      final treeData = jsonDecode(treeOutput) as Map<String, dynamic>;
+      final ancestryJson = treeData['Ancestry'] as List<dynamic>;
+      ancestry = ancestryJson.map((e) {
+        final map = e as Map<String, dynamic>;
+        return (pid: map['PID'] as int, command: map['Command'] as String);
+      }).toList();
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  return DartProcess(
+    pid: p,
+    cmdline: cmdline,
+    cwd: cwd,
+    reason: 'since it is a protected process (current script or child).',
+    ancestry: ancestry,
+  );
+}
+
+Future<({String reason, int? ownerPid})> _resolveOwnerReason(
+  int? ppid,
+  List<String>? env,
+) async {
+  if (ppid != 1) {
+    return (reason: '', ownerPid: null);
+  }
+
+  final vscodePidStr = env
+      ?.where((String e) => e.startsWith('VSCODE_PID='))
+      .firstOrNull;
+
+  if (vscodePidStr != null) {
+    final vscodePid = int.tryParse(vscodePidStr.split('=')[1]);
+    if (vscodePid != null && await isProcessRunning(vscodePid)) {
+      return (
+        reason:
+            'parent is launchd, but since VS Code '
+            '(PID $vscodePid) is running.',
+        ownerPid: vscodePid,
+      );
+    }
+  }
+
+  return (reason: 'Orphaned', ownerPid: null);
+}
+
+typedef _PidAncestry = ({int pid, List<({int pid, String command})> ancestry});
+
 Future<List<_ProcessNode>> _buildTree(List<DartProcess> processes) async {
   final nodes = <int, _ProcessNode>{};
 
@@ -303,46 +318,9 @@ Future<List<_ProcessNode>> _buildTree(List<DartProcess> processes) async {
   // 3. Fetch ancestries concurrently
   final pool = Pool(4);
   final ancestriesList = await pool
-      .forEach(parentToPid.values, (pid) async {
-        final treeResult = await Process.run('witr', [
-          '--pid',
-          pid.toString(),
-          '--tree',
-          '--json',
-        ]);
-
-        if (treeResult.exitCode == 0 ||
-            treeResult.stdout.toString().isNotEmpty) {
-          try {
-            final treeOutput = treeResult.stdout as String;
-            final treeData = jsonDecode(treeOutput) as Map<String, dynamic>;
-            final ancestryJson = treeData['Ancestry'] as List<dynamic>;
-            final ancestry = ancestryJson.map((e) {
-              final map = e as Map<String, dynamic>;
-              return (
-                pid: map['PID'] as int,
-                command: map['Command'] as String,
-              );
-            }).toList();
-
-            return (pid: pid, ancestry: ancestry);
-          } catch (e) {
-            stderr
-              ..writeln('Failed to parse ancestry for PID $pid: $e')
-              ..writeln('Output was: ${treeResult.stdout}');
-          }
-        } else {
-          stderr
-            ..writeln(
-              'witr --tree failed for PID $pid with exit code '
-              '${treeResult.exitCode}',
-            )
-            ..writeln('Stderr: ${treeResult.stderr}');
-        }
-        return null;
-      })
+      .forEach(parentToPid.values, _fetchPidAncestry)
       .where((r) => r != null)
-      .cast<({int pid, List<({int pid, String command})> ancestry})>()
+      .cast<_PidAncestry>()
       .toList();
 
   final ancestries = Map.fromEntries(
@@ -350,6 +328,51 @@ Future<List<_ProcessNode>> _buildTree(List<DartProcess> processes) async {
   );
 
   // 4. Build the tree
+  return _linkProcessNodes(processes, nodes, parentToPid, ancestries);
+}
+
+Future<_PidAncestry?> _fetchPidAncestry(int pid) async {
+  final treeResult = await Process.run('witr', [
+    '--pid',
+    pid.toString(),
+    '--tree',
+    '--json',
+  ]);
+
+  if (treeResult.exitCode != 0 && treeResult.stdout.toString().isEmpty) {
+    stderr
+      ..writeln(
+        'witr --tree failed for PID $pid with exit code '
+        '${treeResult.exitCode}',
+      )
+      ..writeln('Stderr: ${treeResult.stderr}');
+    return null;
+  }
+
+  try {
+    final treeOutput = treeResult.stdout as String;
+    final treeData = jsonDecode(treeOutput) as Map<String, dynamic>;
+    final ancestryJson = treeData['Ancestry'] as List<dynamic>;
+    final ancestry = ancestryJson.map((e) {
+      final map = e as Map<String, dynamic>;
+      return (pid: map['PID'] as int, command: map['Command'] as String);
+    }).toList();
+
+    return (pid: pid, ancestry: ancestry);
+  } catch (e) {
+    stderr
+      ..writeln('Failed to parse ancestry for PID $pid: $e')
+      ..writeln('Output was: ${treeResult.stdout}');
+    return null;
+  }
+}
+
+Future<List<_ProcessNode>> _linkProcessNodes(
+  List<DartProcess> processes,
+  Map<int, _ProcessNode> nodes,
+  Map<int, int> parentToPid,
+  Map<int, List<({int pid, String command})>> ancestries,
+) async {
   final roots = <_ProcessNode>[];
 
   for (final p in processes) {
@@ -357,80 +380,81 @@ Future<List<_ProcessNode>> _buildTree(List<DartProcess> processes) async {
     final ppid = p.ppid;
     final node = nodes[pid]!;
 
-    if (p.ownerPid != null) {
-      final ownerNode = nodes[p.ownerPid];
-      if (ownerNode != null) {
-        if (!ownerNode.children.contains(node)) {
-          ownerNode.children.add(node);
-        }
-        continue;
-      }
+    if (p.ownerPid != null && nodes[p.ownerPid] != null) {
+      nodes[p.ownerPid]!.children.addUnique(node);
+      continue;
     }
 
     if (ppid == null || ppid == 1) {
-      if (!roots.contains(node)) {
-        roots.add(node);
-      }
+      roots.addUnique(node);
       continue;
     }
 
     if (nodes.containsKey(ppid)) {
-      // Parent is a Dart process we know about. Link it.
-      if (!nodes[ppid]!.children.contains(node)) {
-        nodes[ppid]!.children.add(node);
-      }
+      nodes[ppid]!.children.addUnique(node);
     } else {
-      // Parent is non-Dart. We should have fetched ancestry for it!
-      final ancestry = ancestries[pid] ?? ancestries[parentToPid[ppid]];
-
-      if (ancestry != null) {
-        _ProcessNode? prevNode;
-        for (final ancestor in ancestry) {
-          final aPid = ancestor.pid;
-          final aName = ancestor.command;
-
-          var aNode = nodes[aPid];
-          if (aNode == null) {
-            final cwd = await getProcessCwd(aPid);
-            aNode = _ProcessNode(
-              pid: aPid,
-              cmdline: aName,
-              reason: '',
-              isDart: false,
-              cwd: cwd,
-            );
-            nodes[aPid] = aNode;
-          }
-
-          if (prevNode == null) {
-            if (!roots.contains(aNode)) {
-              roots.add(aNode);
-            }
-          } else {
-            if (!prevNode.children.contains(aNode)) {
-              prevNode.children.add(aNode);
-            }
-          }
-          prevNode = aNode;
-        }
-
-        // Link current node to the parent in ancestry
-        if (ancestry.length >= 2) {
-          final parentPid = ancestry[ancestry.length - 2].pid;
-          final parentNode = nodes[parentPid];
-          if (parentNode != null) {
-            if (!parentNode.children.contains(node)) {
-              parentNode.children.add(node);
-            }
-          }
-        }
-      } else {
-        // Fallback if ancestry fetch failed
-        if (!roots.contains(node)) {
-          roots.add(node);
-        }
-      }
+      await _linkNonDartParent(
+        node,
+        pid,
+        ppid,
+        nodes,
+        parentToPid,
+        ancestries,
+        roots,
+      );
     }
   }
   return roots;
+}
+
+Future<void> _linkNonDartParent(
+  _ProcessNode node,
+  int pid,
+  int ppid,
+  Map<int, _ProcessNode> nodes,
+  Map<int, int> parentToPid,
+  Map<int, List<({int pid, String command})>> ancestries,
+  List<_ProcessNode> roots,
+) async {
+  final ancestry = ancestries[pid] ?? ancestries[parentToPid[ppid]];
+  if (ancestry == null) {
+    roots.addUnique(node);
+    return;
+  }
+
+  _ProcessNode? prevNode;
+  for (final ancestor in ancestry) {
+    var aNode = nodes[ancestor.pid];
+    if (aNode == null) {
+      final cwd = await getProcessCwd(ancestor.pid);
+      aNode = _ProcessNode(
+        pid: ancestor.pid,
+        cmdline: ancestor.command,
+        reason: '',
+        isDart: false,
+        cwd: cwd,
+      );
+      nodes[ancestor.pid] = aNode;
+    }
+
+    if (prevNode == null) {
+      roots.addUnique(aNode);
+    } else {
+      prevNode.children.addUnique(aNode);
+    }
+    prevNode = aNode;
+  }
+
+  if (ancestry.length >= 2) {
+    final parentNode = nodes[ancestry[ancestry.length - 2].pid];
+    parentNode?.children.addUnique(node);
+  }
+}
+
+extension on List<_ProcessNode> {
+  void addUnique(_ProcessNode node) {
+    if (!contains(node)) {
+      add(node);
+    }
+  }
 }

--- a/lib/src/git_org_clean.dart
+++ b/lib/src/git_org_clean.dart
@@ -42,57 +42,14 @@ Future<void> runGitOrgClean(CleanArgs args, {DateTime? now}) async {
 
   print('Scanning organization "$org" using gh...');
 
-  List<Map<String, dynamic>> repos;
-  try {
-    final output = await runProcess('gh', [
-      'repo',
-      'list',
-      org,
-      '--limit',
-      '1000',
-      '--json',
-      'name,isFork,pushedAt,isArchived,isPrivate,url,parent,viewerPermission',
-    ]);
-    final decoded = jsonDecode(output);
-    if (decoded is! List) {
-      throw const FormatException('Expected a list of repositories from gh');
-    }
-    repos = decoded.cast<Map<String, dynamic>>();
-  } on ProcessException catch (e) {
-    if (e.message.contains('check your internet connection') ||
-        e.message.contains('not authenticated') ||
-        e.message.contains('scopes')) {
-      setError(
-        message:
-            'GitHub CLI failed to list repositories.\n'
-            'Please ensure you are authenticated by running:\n'
-            '  gh auth login\n'
-            'Or refresh scopes if you lack access:\n'
-            '  gh auth refresh -s repo,read:org\n\n'
-            'Error: ${e.message}',
-        exitCode: ExitCode.tempFail.code,
-      );
-      return;
-    }
-    setError(
-      message: 'Failed to run gh: ${e.message}',
-      exitCode: ExitCode.software.code,
-    );
-    return;
-  } catch (e) {
-    setError(
-      message: 'Unexpected error fetching repositories: $e',
-      exitCode: ExitCode.software.code,
-    );
-    return;
-  }
+  final repos = await _fetchOrgRepos(org);
+  if (repos == null) return;
 
   if (repos.isEmpty) {
     print('No repositories found in organization "$org".');
     return;
   }
 
-  // Graceful Downgrade Warning: Check if we successfully fetched private repos.
   final hasPrivate = repos.any((r) => r['isPrivate'] == true);
   if (!hasPrivate) {
     print(
@@ -105,76 +62,13 @@ Future<void> runGitOrgClean(CleanArgs args, {DateTime? now}) async {
     print('');
   }
 
-  final forks = <Map<String, dynamic>>[];
-  final stale = <Map<String, dynamic>>[];
-  final active = <Map<String, dynamic>>[];
-  final archived = <Map<String, dynamic>>[];
+  final (:forks, :stale, :active, :archived) = _categorizeRepos(
+    repos,
+    currentTime,
+  );
 
-  for (final repo in repos) {
-    if (repo['isArchived'] == true) {
-      archived.add(repo);
-      continue;
-    }
-
-    final pushedAtStr = repo['pushedAt'] as String?;
-    DateTime? pushedAt;
-    if (pushedAtStr != null && pushedAtStr.isNotEmpty) {
-      pushedAt = DateTime.tryParse(pushedAtStr);
-    }
-
-    final isFork = repo['isFork'] == true;
-    final isStale =
-        pushedAt != null && currentTime.difference(pushedAt).inDays > 365;
-
-    if (isFork) {
-      forks.add(repo);
-    } else if (isStale) {
-      stale.add(repo);
-    } else {
-      active.add(repo);
-    }
-  }
-
-  // Sort forks by pushedAt ascending (oldest push first)
-  forks.sort((a, b) {
-    final aPushed = a['pushedAt'] as String? ?? '';
-    final bPushed = b['pushedAt'] as String? ?? '';
-    return aPushed.compareTo(bPushed);
-  });
-
-  // Sort stale repos by pushedAt ascending (oldest push first)
-  stale.sort((a, b) {
-    final aPushed = a['pushedAt'] as String? ?? '';
-    final bPushed = b['pushedAt'] as String? ?? '';
-    return aPushed.compareTo(bPushed);
-  });
-
-  // Check branch sync status for the 50 oldest forks
   final oldestForks = forks.take(50).toList();
-  if (oldestForks.isNotEmpty) {
-    print('Checking branch sync status for the oldest forks...');
-    final forkPool = Pool(3);
-    final forkFutures = <Future<void>>[];
-
-    for (final repo in oldestForks) {
-      final parent = repo['parent'] as Map<String, dynamic>?;
-      if (parent != null) {
-        forkFutures.add(
-          forkPool.withResource(() async {
-            final status = await _checkForkSync(
-              org,
-              repo['name'] as String,
-              parent,
-            );
-            repo['unsyncedStatus'] = status;
-          }),
-        );
-      } else {
-        repo['unsyncedStatus'] = 'No parent info';
-      }
-    }
-    await Future.wait(forkFutures);
-  }
+  await _checkOldestForksSync(org, oldestForks);
 
   final safeForks = <Map<String, dynamic>>[];
   final unsafeForks = <Map<String, dynamic>>[];
@@ -188,7 +82,6 @@ Future<void> runGitOrgClean(CleanArgs args, {DateTime? now}) async {
     }
   }
 
-  // Generate Report in Markdown format
   final buffer = StringBuffer()
     ..writeln('# GitHub Org Cleanup Report: $org')
     ..writeln(
@@ -203,134 +96,299 @@ Future<void> runGitOrgClean(CleanArgs args, {DateTime? now}) async {
     ..writeln('- **Active Repos**: ${active.length}')
     ..writeln();
 
-  String timeAgo(String? dateStr) {
-    if (dateStr == null || dateStr.isEmpty) return 'never';
-    final parsed = DateTime.tryParse(dateStr);
-    if (parsed == null) return dateStr;
-    final diff = currentTime.difference(parsed);
-    if (diff.inDays > 365) {
-      final years = (diff.inDays / 365).floor();
-      return "$years year${years > 1 ? 's' : ''} ago";
-    }
-    if (diff.inDays > 30) {
-      final months = (diff.inDays / 30).floor();
-      return "$months month${months > 1 ? 's' : ''} ago";
-    }
-    if (diff.inDays > 0) {
-      return "${diff.inDays} day${diff.inDays > 1 ? 's' : ''} ago";
-    }
-    return 'today';
-  }
+  _writeSafeForks(buffer, safeForks, currentTime);
+  _writeUnsafeForks(buffer, unsafeForks, currentTime);
+  _writeStaleRepos(buffer, stale, currentTime);
+  _writeActiveAndArchived(buffer, active, archived, currentTime);
 
-  String formatRepoName(Map<String, dynamic> repo) {
-    final name = repo['name'] as String;
-    final url = repo['url'] as String? ?? '';
-    final visibility = repo['isPrivate'] == true ? 'private' : 'public';
-    return '[$name]($url) ($visibility)';
-  }
-
-  String isActionable(Map<String, dynamic> repo) {
-    final perm = repo['viewerPermission'] as String?;
-    return perm == 'ADMIN' ? 'Yes (Admin)' : 'No ($perm)';
-  }
-
-  if (safeForks.isNotEmpty) {
-    buffer
-      ..writeln('## 🟢 Slam Dunk: Safe to Delete (Forks fully synced)')
-      ..writeln(
-        'These forks have no unsynced branches/commits relative '
-        'to upstream. You can delete them safely. (Ordered oldest-push first)',
-      )
-      ..writeln()
-      ..writeln('| Repository | Upstream | Last Push | Actionable? |')
-      ..writeln('| :--- | :--- | :--- | :--- |');
-    for (final repo in safeForks) {
-      final upstream =
-          _upstreamRepo(repo['parent'] as Map<String, dynamic>?) ??
-          '(Inaccessible)';
-      buffer.writeln(
-        '| ${formatRepoName(repo)} | `$upstream` | '
-        '${timeAgo(repo['pushedAt'] as String?)} | '
-        '${isActionable(repo)} |',
-      );
-    }
-    buffer.writeln();
-  }
-
-  if (unsafeForks.isNotEmpty) {
-    buffer
-      ..writeln('## ⚠️ Forks with Unsynced Changes (Review Required)')
-      ..writeln(
-        'These forks have one or more branches with commits not '
-        'present upstream. Review before deleting. (Ordered oldest-push first)',
-      )
-      ..writeln()
-      ..writeln(
-        '| Repository | Upstream | Last Push | Unsynced Branches | '
-        'Actionable? |',
-      )
-      ..writeln('| :--- | :--- | :--- | :--- | :--- |');
-    for (final repo in unsafeForks) {
-      final upstream =
-          _upstreamRepo(repo['parent'] as Map<String, dynamic>?) ??
-          '(Inaccessible)';
-      final unsynced = repo['unsyncedStatus'] as String? ?? 'Not checked';
-      buffer.writeln(
-        '| ${formatRepoName(repo)} | `$upstream` | '
-        '${timeAgo(repo['pushedAt'] as String?)} | $unsynced | '
-        '${isActionable(repo)} |',
-      );
-    }
-    buffer.writeln();
-  }
-
-  if (stale.isNotEmpty) {
-    buffer
-      ..writeln('## 💤 Recommended for Archiving (Stale Repositories)')
-      ..writeln(
-        'Repositories with no push activity in over 365 days. '
-        '(Ordered oldest-push first)',
-      )
-      ..writeln()
-      ..writeln('| Repository | Last Push | Actionable? | Description |')
-      ..writeln('| :--- | :--- | :--- | :--- |');
-    for (final repo in stale) {
-      final desc = repo['description'] as String? ?? '';
-      buffer.writeln(
-        '| ${formatRepoName(repo)} | '
-        '${timeAgo(repo['pushedAt'] as String?)} | '
-        '${isActionable(repo)} | $desc |',
-      );
-    }
-    buffer.writeln();
-  }
-
-  if (active.isNotEmpty || archived.isNotEmpty) {
-    buffer
-      ..writeln('## ✅ Active or Already Archived Repositories')
-      ..writeln('(Listed here for completeness)')
-      ..writeln();
-    if (active.isNotEmpty) {
-      buffer.writeln('### Active Repositories (Pushed in last 365 days)');
-      for (final repo in active) {
-        buffer.writeln(
-          '- ${formatRepoName(repo)} - Last push '
-          '${timeAgo(repo['pushedAt'] as String?)}',
-        );
-      }
-      buffer.writeln();
-    }
-    if (archived.isNotEmpty) {
-      buffer.writeln('### Already Archived Repositories');
-      for (final repo in archived) {
-        buffer.writeln('- ${formatRepoName(repo)}');
-      }
-      buffer.writeln();
-    }
-  }
-
-  // Print the report to stdout
   print(buffer.toString());
+}
+
+Future<List<Map<String, dynamic>>?> _fetchOrgRepos(String org) async {
+  try {
+    final output = await runProcess('gh', [
+      'repo',
+      'list',
+      org,
+      '--limit',
+      '1000',
+      '--json',
+      'name,isFork,pushedAt,isArchived,isPrivate,url,parent,viewerPermission',
+    ]);
+    final decoded = jsonDecode(output);
+    if (decoded is! List) {
+      throw const FormatException('Expected a list of repositories from gh');
+    }
+    return decoded.cast<Map<String, dynamic>>();
+  } on ProcessException catch (e) {
+    if (e.message.contains('check your internet connection') ||
+        e.message.contains('not authenticated') ||
+        e.message.contains('scopes')) {
+      setError(
+        message:
+            'GitHub CLI failed to list repositories.\n'
+            'Please ensure you are authenticated by running:\n'
+            '  gh auth login\n'
+            'Or refresh scopes if you lack access:\n'
+            '  gh auth refresh -s repo,read:org\n\n'
+            'Error: ${e.message}',
+        exitCode: ExitCode.tempFail.code,
+      );
+      return null;
+    }
+    setError(
+      message: 'Failed to run gh: ${e.message}',
+      exitCode: ExitCode.software.code,
+    );
+    return null;
+  } catch (e) {
+    setError(
+      message: 'Unexpected error fetching repositories: $e',
+      exitCode: ExitCode.software.code,
+    );
+    return null;
+  }
+}
+
+typedef _CategorizedRepos = ({
+  List<Map<String, dynamic>> forks,
+  List<Map<String, dynamic>> stale,
+  List<Map<String, dynamic>> active,
+  List<Map<String, dynamic>> archived,
+});
+
+_CategorizedRepos _categorizeRepos(
+  List<Map<String, dynamic>> repos,
+  DateTime currentTime,
+) {
+  final forks = <Map<String, dynamic>>[];
+  final stale = <Map<String, dynamic>>[];
+  final active = <Map<String, dynamic>>[];
+  final archived = <Map<String, dynamic>>[];
+
+  for (final repo in repos) {
+    if (repo['isArchived'] == true) {
+      archived.add(repo);
+      continue;
+    }
+
+    final pushedAtStr = repo['pushedAt'] as String?;
+    final pushedAt = pushedAtStr != null && pushedAtStr.isNotEmpty
+        ? DateTime.tryParse(pushedAtStr)
+        : null;
+
+    final isFork = repo['isFork'] == true;
+    final isStale =
+        pushedAt != null && currentTime.difference(pushedAt).inDays > 365;
+
+    if (isFork) {
+      forks.add(repo);
+    } else if (isStale) {
+      stale.add(repo);
+    } else {
+      active.add(repo);
+    }
+  }
+
+  forks.sort((a, b) {
+    final aPushed = a['pushedAt'] as String? ?? '';
+    final bPushed = b['pushedAt'] as String? ?? '';
+    return aPushed.compareTo(bPushed);
+  });
+
+  stale.sort((a, b) {
+    final aPushed = a['pushedAt'] as String? ?? '';
+    final bPushed = b['pushedAt'] as String? ?? '';
+    return aPushed.compareTo(bPushed);
+  });
+
+  return (forks: forks, stale: stale, active: active, archived: archived);
+}
+
+Future<void> _checkOldestForksSync(
+  String org,
+  List<Map<String, dynamic>> oldestForks,
+) async {
+  if (oldestForks.isEmpty) return;
+
+  print('Checking branch sync status for the oldest forks...');
+  final forkPool = Pool(3);
+  final forkFutures = <Future<void>>[];
+
+  for (final repo in oldestForks) {
+    final parent = repo['parent'] as Map<String, dynamic>?;
+    if (parent != null) {
+      forkFutures.add(
+        forkPool.withResource(() async {
+          final status = await _checkForkSync(
+            org,
+            repo['name'] as String,
+            parent,
+          );
+          repo['unsyncedStatus'] = status;
+        }),
+      );
+    } else {
+      repo['unsyncedStatus'] = 'No parent info';
+    }
+  }
+  await Future.wait(forkFutures);
+}
+
+String _timeAgo(String? dateStr, DateTime currentTime) {
+  if (dateStr == null || dateStr.isEmpty) return 'never';
+  final parsed = DateTime.tryParse(dateStr);
+  if (parsed == null) return dateStr;
+  final diff = currentTime.difference(parsed);
+  if (diff.inDays > 365) {
+    final years = (diff.inDays / 365).floor();
+    return "$years year${years > 1 ? 's' : ''} ago";
+  }
+  if (diff.inDays > 30) {
+    final months = (diff.inDays / 30).floor();
+    return "$months month${months > 1 ? 's' : ''} ago";
+  }
+  if (diff.inDays > 0) {
+    return "${diff.inDays} day${diff.inDays > 1 ? 's' : ''} ago";
+  }
+  return 'today';
+}
+
+String _formatRepoName(Map<String, dynamic> repo) {
+  final name = repo['name'] as String;
+  final url = repo['url'] as String? ?? '';
+  final visibility = repo['isPrivate'] == true ? 'private' : 'public';
+  return '[$name]($url) ($visibility)';
+}
+
+String _isActionable(Map<String, dynamic> repo) {
+  final perm = repo['viewerPermission'] as String?;
+  return perm == 'ADMIN' ? 'Yes (Admin)' : 'No ($perm)';
+}
+
+void _writeSafeForks(
+  StringBuffer buffer,
+  List<Map<String, dynamic>> safeForks,
+  DateTime currentTime,
+) {
+  if (safeForks.isEmpty) return;
+
+  buffer
+    ..writeln('## 🟢 Slam Dunk: Safe to Delete (Forks fully synced)')
+    ..writeln(
+      'These forks have no unsynced branches/commits relative '
+      'to upstream. You can delete them safely. (Ordered oldest-push first)',
+    )
+    ..writeln()
+    ..writeln('| Repository | Upstream | Last Push | Actionable? |')
+    ..writeln('| :--- | :--- | :--- | :--- |');
+
+  for (final repo in safeForks) {
+    final upstream =
+        _upstreamRepo(repo['parent'] as Map<String, dynamic>?) ??
+        '(Inaccessible)';
+    buffer.writeln(
+      '| ${_formatRepoName(repo)} | `$upstream` | '
+      '${_timeAgo(repo['pushedAt'] as String?, currentTime)} | '
+      '${_isActionable(repo)} |',
+    );
+  }
+  buffer.writeln();
+}
+
+void _writeUnsafeForks(
+  StringBuffer buffer,
+  List<Map<String, dynamic>> unsafeForks,
+  DateTime currentTime,
+) {
+  if (unsafeForks.isEmpty) return;
+
+  buffer
+    ..writeln('## ⚠️ Forks with Unsynced Changes (Review Required)')
+    ..writeln(
+      'These forks have one or more branches with commits not '
+      'present upstream. Review before deleting. (Ordered oldest-push first)',
+    )
+    ..writeln()
+    ..writeln(
+      '| Repository | Upstream | Last Push | Unsynced Branches | '
+      'Actionable? |',
+    )
+    ..writeln('| :--- | :--- | :--- | :--- | :--- |');
+
+  for (final repo in unsafeForks) {
+    final upstream =
+        _upstreamRepo(repo['parent'] as Map<String, dynamic>?) ??
+        '(Inaccessible)';
+    final unsynced = repo['unsyncedStatus'] as String? ?? 'Not checked';
+    buffer.writeln(
+      '| ${_formatRepoName(repo)} | `$upstream` | '
+      '${_timeAgo(repo['pushedAt'] as String?, currentTime)} | $unsynced | '
+      '${_isActionable(repo)} |',
+    );
+  }
+  buffer.writeln();
+}
+
+void _writeStaleRepos(
+  StringBuffer buffer,
+  List<Map<String, dynamic>> stale,
+  DateTime currentTime,
+) {
+  if (stale.isEmpty) return;
+
+  buffer
+    ..writeln('## 💤 Recommended for Archiving (Stale Repositories)')
+    ..writeln(
+      'Repositories with no push activity in over 365 days. '
+      '(Ordered oldest-push first)',
+    )
+    ..writeln()
+    ..writeln('| Repository | Last Push | Actionable? | Description |')
+    ..writeln('| :--- | :--- | :--- | :--- |');
+
+  for (final repo in stale) {
+    final desc = repo['description'] as String? ?? '';
+    buffer.writeln(
+      '| ${_formatRepoName(repo)} | '
+      '${_timeAgo(repo['pushedAt'] as String?, currentTime)} | '
+      '${_isActionable(repo)} | $desc |',
+    );
+  }
+  buffer.writeln();
+}
+
+void _writeActiveAndArchived(
+  StringBuffer buffer,
+  List<Map<String, dynamic>> active,
+  List<Map<String, dynamic>> archived,
+  DateTime currentTime,
+) {
+  if (active.isEmpty && archived.isEmpty) return;
+
+  buffer
+    ..writeln('## ✅ Active or Already Archived Repositories')
+    ..writeln('(Listed here for completeness)')
+    ..writeln();
+
+  if (active.isNotEmpty) {
+    buffer.writeln('### Active Repositories (Pushed in last 365 days)');
+    for (final repo in active) {
+      buffer.writeln(
+        '- ${_formatRepoName(repo)} - Last push '
+        '${_timeAgo(repo['pushedAt'] as String?, currentTime)}',
+      );
+    }
+    buffer.writeln();
+  }
+
+  if (archived.isNotEmpty) {
+    buffer.writeln('### Already Archived Repositories');
+    for (final repo in archived) {
+      buffer.writeln('- ${_formatRepoName(repo)}');
+    }
+    buffer.writeln();
+  }
 }
 
 String? _upstreamRepo(Map<String, dynamic>? parent) => switch (parent) {

--- a/lib/src/tighten.dart
+++ b/lib/src/tighten.dart
@@ -187,35 +187,35 @@ Future<void> _revertWorkspaceChanges(
       continue;
     }
 
-    if (currentFile != null) {
-      final changeMatch = changeRegex.firstMatch(line);
-      if (changeMatch != null) {
-        final packageName = changeMatch.group(1)!;
-        final oldValue = changeMatch.group(2)!;
+    if (currentFile == null) continue;
 
-        // If parsed path is relative, dart pub treats it relative to CWD.
-        // We use it as is with File(currentFile).
+    final changeMatch = changeRegex.firstMatch(line);
+    if (changeMatch == null) continue;
 
-        if (workspacePackages.contains(packageName)) {
-          reverts.putIfAbsent(currentFile, () => []).add((
-            packageName,
-            oldValue,
-          ));
-        }
-      }
+    final packageName = changeMatch.group(1)!;
+    if (workspacePackages.contains(packageName)) {
+      final oldValue = changeMatch.group(2)!;
+      reverts.putIfAbsent(currentFile, () => []).add((packageName, oldValue));
     }
   }
 
-  if (reverts.isNotEmpty) {
-    print('\nReverting changes to workspace packages:');
-    for (final entry in reverts.entries) {
-      final file = entry.key;
-      final changes = entry.value;
-      print('  $file:');
-      for (final (packageName, oldValue) in changes) {
-        print('    - $packageName (restoring $oldValue)');
-        await _revertConstraint(p.join(cwd, file), packageName, oldValue);
-      }
+  await _applyReverts(reverts, cwd);
+}
+
+Future<void> _applyReverts(
+  Map<String, List<(String, String)>> reverts,
+  String cwd,
+) async {
+  if (reverts.isEmpty) return;
+
+  print('\nReverting changes to workspace packages:');
+  for (final entry in reverts.entries) {
+    final file = entry.key;
+    final changes = entry.value;
+    print('  $file:');
+    for (final (packageName, oldValue) in changes) {
+      print('    - $packageName (restoring $oldValue)');
+      await _revertConstraint(p.join(cwd, file), packageName, oldValue);
     }
   }
 }


### PR DESCRIPTION
Decompose complex control flow across production tools to meet the <= 15
cognitive complexity operational ceiling.

* lib/src/dart_clean.dart: Decompose _buildTree, _checkProcess, and
  runDartClean into focused helper methods and guard clause extensions.
* lib/src/git_org_clean.dart: Extract repository fetching, categorization,
  and markdown table generation from runGitOrgClean.
* lib/src/tighten.dart: Apply early guard clause exits and extract
  _applyReverts in _revertWorkspaceChanges.
